### PR TITLE
Add `u` shortcut to update parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
 	
 `i` - Install parser under cursor  
 `x` - Remove parser under cursor  
+`u` - Update parser under cursor  
 `r` - Refresh installation status  
 `q / <Esc>` - Close window  
 
@@ -76,7 +77,7 @@ Your contributions help keep this plugin reliable for everyone. 🙏
 
 - Unix-first development: Primarily tested on macOS/Linux. Windows support may require additional testing.
 - Requires tree-sitter CLI: Ensure tree-sitter is available in your $PATH.
-- No auto-updates: To update a parser, remove it (x) and reinstall (i).
+- No auto-updates: To update a parser, update it manually (u) or remove (x) and reinstall (i) it.
 
 ## 🤝 Contributing
 Pull requests are welcome! Especially for:

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -239,6 +239,7 @@ function M.open()
     vim.keymap.set("n", "r", function() render(buf) end, { buffer = buf, noremap = true, silent = true })
     vim.keymap.set("n", "i", function() M._act("install") end, { buffer = buf, noremap = true, silent = true })
     vim.keymap.set("n", "x", function() M._act("remove") end, { buffer = buf, noremap = true, silent = true })
+    vim.keymap.set("n", "u", function() M._act("update") end, { buffer = buf, noremap = true, silent = true })
 end
 
 function M._act(action)
@@ -248,6 +249,9 @@ function M._act(action)
         install(lang)
     elseif action == "remove" then
         remove(lang)
+    elseif action == "update" then
+        remove(lang)
+        install(lang)
     end
     render(vim.api.nvim_get_current_buf())
 end

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -7,7 +7,7 @@ local src = debug.getinfo(1, "S").source
 local abs = src:sub(1, 1) == "@" and vim.fn.fnamemodify(src:sub(2), ":p") or ""
 local PLUGIN_ROOT = abs ~= "" and vim.fn.fnamemodify(abs, ":h:h:h") or vim.fn.stdpath("config")
 
-local footer = " [i] Install  [x] Remove  [r] Refresh  [q] Close "
+local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [q] Close "
 
 local cfg = {
     parser_dir = vim.fn.stdpath("data") .. "/site/parser",


### PR DESCRIPTION
This PR simply adds the keybinding `u` to update (by chaining `remove()` and `install()`, so basically just a shortcut for `xi`.