### PR TITLE
fix: allow "~" in custom parser_dir and query_dir

### DIFF
--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -110,11 +110,14 @@ function M._install_single(lang)
 
     vim.notify("🔨 Building " .. lang)
     local build = {}
+    local out_path = ppath(lang)
+    local out_dir = vim.fn.fnamemodify(out_path, ":h")
     if info.generate then
-        build = run_cmd(string.format('cd "%s" && tree-sitter generate && tree-sitter build -o "%s"', build_dir,
-            ppath(lang)))
+        build = run_cmd(string.format('mkdir -p "%s" && cd "%s" && tree-sitter generate && tree-sitter build -o "%s"',
+            out_dir, build_dir, out_path))
     else
-        build = run_cmd(string.format('cd "%s" && tree-sitter build -o "%s"', build_dir, ppath(lang)))
+        build = run_cmd(string.format('mkdir -p "%s" && cd "%s" && tree-sitter build -o "%s"', out_dir, build_dir,
+            out_path))
     end
 
     if not build.ok then
@@ -187,6 +190,8 @@ end
 
 function M.setup(opts)
     cfg = vim.tbl_deep_extend("force", cfg, opts or {})
+    cfg.parser_dir = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.expand(cfg.parser_dir), ":p"))
+    cfg.query_dir = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.expand(cfg.query_dir), ":p"))
     vim.fn.mkdir(cfg.parser_dir, "p")
     vim.fn.mkdir(cfg.query_dir, "p")
 


### PR DESCRIPTION
Had an issue where having "~" in the custom directories would not be properly resolved. It instead created a directory named `~` in `.../treesitter-manager.nvim/` (wherever the plugin was installed to).

For example, `parser_dir = "~/.cache/my_parsers"` would lead to `~/.local/share/nvim/lazy/treesitter-manager.nvim/~` being created. But the installation of parsers then fails because `~/.local/share/nvim/lazy/treesitter-manager.nvim/~/.cache/my_parsers` was missing.

This fixes that so it both actually expands stuff like `~` and ensures that the directories exist using `mkdir -p`.