### PR TITLE
feat: add option to automatically install a selection of parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
   dependencies = {}, -- tree-sitter CLI must be installed system-wide
   config = function()
     require("tree-sitter-manager").setup({
-      -- auto_install = { "bash", "lua", "python" }, -- list of parsers to install automatically
+      -- ensure_installed = { "bash", "lua", "python" }, -- list of parsers to install automatically
       -- Optional: custom paths
       -- parser_dir = vim.fn.stdpath("data") .. "/site/parser",
       -- query_dir = vim.fn.stdpath("data") .. "/site/queries",

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -12,7 +12,7 @@ local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [q] Close "
 local cfg = {
     parser_dir = vim.fn.stdpath("data") .. "/site/parser",
     query_dir = vim.fn.stdpath("data") .. "/site/queries",
-    auto_install = {},
+    ensure_installed = {},
 }
 
 local function ext()
@@ -198,7 +198,7 @@ function M.setup(opts)
     if not vim.tbl_contains(rtp, parser_parent) then vim.opt.rtp:prepend(parser_parent) end
     if not vim.tbl_contains(rtp, query_parent) then vim.opt.rtp:prepend(query_parent) end
 
-    for _, lang in ipairs(cfg.auto_install or {}) do
+    for _, lang in ipairs(cfg.ensure_installed or {}) do
         if not repos[lang] then
             vim.notify("⚠ Parser not found in repos: " .. lang, vim.log.levels.WARN)
         else


### PR DESCRIPTION
Similar to nvim-treesitters "ensure_installed" option. Right now, it simply installs them one-after-another, failing if the parser was not found. Probably can be done asynchronously but then the UI should be improved so to avoid a log-salad