### PR TITLE
feat: Add highlighting configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ require("tree-sitter-manager").setup({
 If `use_repo_queries = true` but the repo has no `queries/` directory, a warning is shown
 and the plugin falls back to the bundled queries automatically.
 
+## Treesitter Highlighting
+Treesitter highlighting is enabled by default. If you prefer to use standard regex highlighting for specific languages, use the `nohighlight` option.
+```lua
+require("tree-sitter-manager").setup({
+  -- Use regex highlighting for these languages
+  nohighlight = { "yaml", "zsh" },
+})
+```
+Alternatively, if you prefer an "opt-in" approach, use the `highlight` option.
+```lua
+require("tree-sitter-manager").setup({
+  -- Only enable treesitter highlighting for these languages
+  highlight = { "lua", "c" },
+
+  -- Disable treesitter highlighting
+  -- highlight = {},
+})
+```
+
 ## Usage
 `:TSManager` - Open the parser management interface
 

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -13,7 +13,8 @@ local cfg = {
     ---@type table<string, string|{install_info?: {url: string, location?: string, revision?: string, branch?: string, generate?: boolean, use_repo_queries?: boolean}, requires?: string[]}>
     languages = {},
     ensure_installed = {},
-
+    highlight = true,
+    nohighlight = {},
 }
 
 -- Effective repos: built-in repos merged with user-defined overrides from cfg.languages.
@@ -277,16 +278,22 @@ function M.setup(opts)
     vim.api.nvim_create_user_command("TSManager", function() M.open() end,
         { nargs = 0, desc = "Open Tree-sitter Parsers Manager" })
 
-    local installed_ft = {}
-    for _, lang in ipairs(languages) do
-        if vim.uv.fs_stat(ppath(lang)) then table.insert(installed_ft, lang) end
-    end
-    if #installed_ft > 0 then
-        vim.api.nvim_create_autocmd("FileType", {
-            pattern = installed_ft,
-            callback = function() vim.treesitter.start() end,
-            desc = "Auto-enable treesitter for installed parsers",
-        })
+    if cfg.highlight then
+        local highlight_ft = {}
+        for _, lang in ipairs(languages) do
+            if (cfg.highlight == true or vim.list_contains(cfg.highlight, lang))
+                and not vim.list_contains(cfg.nohighlight, lang)
+                and vim.uv.fs_stat(ppath(lang)) then
+                table.insert(highlight_ft, lang)
+            end
+        end
+        if #highlight_ft > 0 then
+            vim.api.nvim_create_autocmd('FileType', {
+                pattern = highlight_ft,
+                callback = function() vim.treesitter.start() end,
+                desc = 'Auto-enable treesitter for installed parsers'
+            })
+        end
     end
 end
 


### PR DESCRIPTION
### Motivation
For certain languages I like the regex highlighting more. And the plugin overwrites all `FileType` autocommands running `lua vim.treesitter.stop()`, because it's loaded after.

### Example
```lua
-- default
require('tree-sitter-manager').setup({
  highlight = true,
  nohighlight = {},
})
-- disable some languages
require('tree-sitter-manager').setup({
  highlight = true,
  nohighlight = { 'yaml' },
})
-- highlight only certain languages
require('tree-sitter-manager').setup({
  highlight = { 'c', 'lua' },
})
```