### PR TITLE
fix: Replaces emoji in the README.md with more standard markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# 🌳 tree-sitter-manager.nvim
-
+# tree-sitter-manager.nvim
 A lightweight Tree-sitter parser manager for Neovim.
 
 <img width="560" height="573" alt="изображение" src="https://github.com/user-attachments/assets/8ec50e9a-6c5a-4484-b231-5c13e069b1fc" />
 
-## 📜 Why this plugin?
-
+## Why this plugin?
 Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a built-in parser installer. With [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) now archived, this plugin provides a lightweight, actively maintained alternative that makes installing parsers and adding new languages effortless.
 
 **tree-sitter-manager.nvim** provides a minimal alternative for:
@@ -13,27 +11,24 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
 - Automatically copying queries for syntax highlighting
 - Managing parsers through a clean TUI interface
 
-## ✨ Features
+## Features
+- Install parsers directly from Tree-sitter repositories
+- Dynamic FileType autocmd registration for installed parsers
+- Works with any plugin manager (lazy, packer, vim-plug, native packages)
+- **Custom/fork repositories**: Override any language or add new ones via `setup()`
+- **Repository queries**: Use `use_repo_queries` to use query files bundled in the grammar repo itself
 
-- 🎯 Install parsers directly from Tree-sitter repositories
-- ⚡ Dynamic FileType autocmd registration for installed parsers
-- 🔧 Works with any plugin manager (lazy, packer, vim-plug, native packages)
-- 🔀 **Custom/fork repositories**: Override any language or add new ones via `setup()`
-- 📂 **Repository queries**: Use `use_repo_queries` to use query files bundled in the grammar repo itself
-
-## 📋 Requirements
-
+## Requirements
 ### Mandatory
-- **Neovim 0.12+** 
-- **tree-sitter CLI** 
+- **Neovim 0.12+**
+- **tree-sitter CLI**
 - **git** (for cloning parser repositories)
 - **C compiler** (gcc/clang for building parsers)
 
 ### Optional
 - Nerd Font (for proper display of icons ✅❌📦)
 
-## 📦 Installation
-
+## Installation
 ### lazy.nvim
 ```lua
 {
@@ -50,14 +45,12 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
 }
 ```
 
-## 🔀 Custom / Fork Repositories
-
+## Custom / Fork Repositories
 You can override built-in language definitions or add entirely new ones via the `languages`
 option in `setup()`. This keeps `repos.lua` clean — no changes to the plugin repository are
 needed.
 
 ### Override a built-in language with a fork
-
 ```lua
 require("tree-sitter-manager").setup({
   languages = {
@@ -76,7 +69,6 @@ require("tree-sitter-manager").setup({
 ```
 
 ### Add a language not in the built-in list
-
 ```lua
 require("tree-sitter-manager").setup({
   languages = {
@@ -91,7 +83,6 @@ require("tree-sitter-manager").setup({
 ```
 
 ### `use_repo_queries` behaviour
-
 | Value | Query source |
 |-------|-------------|
 | `false` (default) | Queries bundled in `runtime/queries/<lang>/` of this plugin |
@@ -100,39 +91,35 @@ require("tree-sitter-manager").setup({
 If `use_repo_queries = true` but the repo has no `queries/` directory, a warning is shown
 and the plugin falls back to the bundled queries automatically.
 
-## 🚀 Usage
-
+## Usage
 `:TSManager` - Open the parser management interface
 
 ## ⌨️ Keybindings
-	
 `i` - Install parser under cursor  
 `x` - Remove parser under cursor  
 `u` - Update parser under cursor  
 `r` - Refresh installation status  
 `q / <Esc>` - Close window  
 
-## 📚 Queries
-Syntax highlighting queries (highlights.scm, injections.scm, etc.) were sourced from the archived [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
- repository and placed in `runtime/queries/`.
+## Queries
+Syntax highlighting queries (highlights.scm, injections.scm, etc.) were sourced from the archived [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) repository and placed in `runtime/queries/`.
 
-## 🔗 Parser Repository Links
-
+## Parser Repository Links
 Parser repository URLs in `repos.lua` are sourced from the archived [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) repository. 
 
-> ⚠️ **Disclaimer**: These links are provided as-is. Due to the large number of parsers, each URL cannot be manually verified for current availability or compatibility. If you encounter a broken link, outdated revision, or build failure, please:
+> [!WARNING]
+> These links are provided as-is. Due to the large number of parsers, each URL cannot be manually verified for current availability or compatibility. If you encounter a broken link, outdated revision, or build failure, please:
 > - Open an [issue](https://github.com/romus204/tree-sitter-manager.nvim/issues) with details
 > - Or submit a [pull request](https://github.com/romus204/tree-sitter-manager.nvim/pulls) with a fix
 
-Your contributions help keep this plugin reliable for everyone. 🙏
+Your contributions help keep this plugin reliable for everyone.
 
-## ⚠️ Known Limitations
-
+## Known Limitations
 - Unix-first development: Primarily tested on macOS/Linux. Windows support may require additional testing.
 - Requires tree-sitter CLI: Ensure tree-sitter is available in your $PATH.
 - No auto-updates: To update a parser, update it manually (u) or remove (x) and reinstall (i) it.
 
-## 🤝 Contributing
+## Contributing
 Pull requests are welcome! Especially for:
 
 - Adding new languages to repos.lua

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ and the plugin falls back to the bundled queries automatically.
 ## Usage
 `:TSManager` - Open the parser management interface
 
-## ⌨️ Keybindings
+## Keybindings
 `i` - Install parser under cursor  
 `x` - Remove parser under cursor  
 `u` - Update parser under cursor  


### PR DESCRIPTION
Trust me on this, the current usage of emoji makes the readme seem like AI-generated slop, and leaves a bad impression to some users. I kept the emoji in parts where it's still contextually relevant, and replaced one with a warning comment.