### PR TITLE
fix: highlight autocmd not registered when parsers not yet installed

### DIFF
--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -41,7 +41,7 @@ M.cfg = {
 M.base_repos = repos
 M.effective_repos = repos
 M.languages = vim.tbl_keys(repos)
-table.sort(M.languages)
 M.filetypes = filetypes
+M.filetype_language = {}
 
 return M

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -44,6 +44,5 @@ M.base_repos = repos
 M.effective_repos = repos
 M.languages = vim.tbl_keys(repos)
 M.filetypes = filetypes
-M.filetype_language = {}
 
 return M

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -22,6 +22,12 @@ function M.setup(opts)
     state.languages = vim.tbl_keys(state.effective_repos)
     table.sort(state.languages)
 
+    for lang, fts in pairs(state.filetypes) do
+        for _, ft in ipairs(fts) do
+            state.filetype_language[ft] = lang
+        end
+    end
+
     vim.fn.mkdir(state.cfg.parser_dir, "p")
     vim.fn.mkdir(state.cfg.query_dir, "p")
 
@@ -85,21 +91,24 @@ function M.setup(opts)
     })
 
     if state.cfg.highlight then
-        local highlight_ft = {}
+        local filetypes = {}
         for _, lang in ipairs(state.languages) do
             if
                 (state.cfg.highlight == true or vim.list_contains(state.cfg.highlight, lang))
                 and not vim.list_contains(state.cfg.nohighlight, lang)
             then
-                table.insert(highlight_ft, lang)
-                vim.list_extend(highlight_ft, state.filetypes[lang] or {})
+                table.insert(filetypes, lang)
+                vim.list_extend(filetypes, state.filetypes[lang] or {})
             end
         end
-        if #highlight_ft > 0 then
+        if #filetypes > 0 then
             vim.api.nvim_create_autocmd("FileType", {
-                pattern = highlight_ft,
-                callback = function()
-                    pcall(vim.treesitter.start)
+                pattern = filetypes,
+                callback = function(a)
+                    local lang = state.filetype_language[a.match] or a.match
+                    if vim.uv.fs_stat(util.ppath(lang)) then
+                        vim.treesitter.start(a.buf, a.match)
+                    end
                 end,
                 desc = "Auto-enable treesitter for installed parsers",
             })

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -22,12 +22,6 @@ function M.setup(opts)
     state.languages = vim.tbl_keys(state.effective_repos)
     table.sort(state.languages)
 
-    for lang, fts in pairs(state.filetypes) do
-        for _, ft in ipairs(fts) do
-            state.filetype_language[ft] = lang
-        end
-    end
-
     vim.fn.mkdir(state.cfg.parser_dir, "p")
     vim.fn.mkdir(state.cfg.query_dir, "p")
 

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -90,7 +90,6 @@ function M.setup(opts)
             if
                 (state.cfg.highlight == true or vim.list_contains(state.cfg.highlight, lang))
                 and not vim.list_contains(state.cfg.nohighlight, lang)
-                and vim.uv.fs_stat(util.ppath(lang))
             then
                 table.insert(highlight_ft, lang)
                 vim.list_extend(highlight_ft, state.filetypes[lang] or {})
@@ -100,7 +99,7 @@ function M.setup(opts)
             vim.api.nvim_create_autocmd("FileType", {
                 pattern = highlight_ft,
                 callback = function()
-                    vim.treesitter.start()
+                    pcall(vim.treesitter.start)
                 end,
                 desc = "Auto-enable treesitter for installed parsers",
             })

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -60,6 +60,28 @@ function M.setup(opts)
         })
     end
 
+    if state.cfg.highlight then
+        local filetypes = {}
+        for _, lang in ipairs(state.languages) do
+            if
+                (state.cfg.highlight == true or vim.list_contains(state.cfg.highlight, lang))
+                and not vim.list_contains(state.cfg.nohighlight, lang)
+            then
+                table.insert(filetypes, lang)
+                vim.list_extend(filetypes, state.filetypes[lang] or {})
+            end
+        end
+        if #filetypes > 0 then
+            vim.api.nvim_create_autocmd("FileType", {
+                pattern = filetypes,
+                callback = function(a)
+                    pcall(vim.treesitter.start)
+                end,
+                desc = "Auto-enable treesitter highlighting",
+            })
+        end
+    end
+
     vim.api.nvim_create_user_command("TSManager", function()
         M.open()
     end, { nargs = 0, desc = "Open Tree-sitter Parsers Manager" })
@@ -89,31 +111,6 @@ function M.setup(opts)
         end,
         desc = "Remove treesitter parsers",
     })
-
-    if state.cfg.highlight then
-        local filetypes = {}
-        for _, lang in ipairs(state.languages) do
-            if
-                (state.cfg.highlight == true or vim.list_contains(state.cfg.highlight, lang))
-                and not vim.list_contains(state.cfg.nohighlight, lang)
-            then
-                table.insert(filetypes, lang)
-                vim.list_extend(filetypes, state.filetypes[lang] or {})
-            end
-        end
-        if #filetypes > 0 then
-            vim.api.nvim_create_autocmd("FileType", {
-                pattern = filetypes,
-                callback = function(a)
-                    local lang = state.filetype_language[a.match] or a.match
-                    if vim.uv.fs_stat(util.ppath(lang)) then
-                        vim.treesitter.start()
-                    end
-                end,
-                desc = "Auto-enable treesitter for installed parsers",
-            })
-        end
-    end
 end
 
 return M

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -107,7 +107,7 @@ function M.setup(opts)
                 callback = function(a)
                     local lang = state.filetype_language[a.match] or a.match
                     if vim.uv.fs_stat(util.ppath(lang)) then
-                        vim.treesitter.start(a.buf, a.match)
+                        vim.treesitter.start()
                     end
                 end,
                 desc = "Auto-enable treesitter for installed parsers",

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -39,6 +39,7 @@ function M._install_single(lang, callback)
         if ok then
             vim.notify("✓ Installed  " .. lang)
             vim.treesitter.query.get:clear()
+            vim.cmd("bufdo let &filetype = &filetype")
         end
         _callback(ok)
     end


### PR DESCRIPTION
## Problem

 When `cfg.highlight` was configured, the `FileType` autocmd was only
 registered for languages whose parser files already existed at `setup()` time.
 This caused highlight to silently not work if parsers were installed later
 (e.g. via `ensure_installed`) or if the parser directory was added to RTP
 after the check.

 ## Changes

 - Remove `vim.uv.fs_stat` check at autocmd registration time
 - Use `pcall(vim.treesitter.start)` in the callback instead, so errors
   are silently ignored when a parser is missing at the time a file is opened
