### PR TITLE
feat: Add custom border style

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
     require("tree-sitter-manager").setup({
       -- Default Options
       -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session
+      -- border = nil, -- border style for the window (e.g. "rounded", "single"), if nil, use the default border style defined by 'vim.o.winborder'
       -- auto_install = false, -- if enabled, install missing parsers when editing a new file
       -- highlight = true, -- treesitter highlighting is enabled by default
       -- languages = {}, -- override or add new parser sources

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
     require("tree-sitter-manager").setup({
       -- Default Options
       -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session
-      -- border = nil, -- border style for the window (e.g. "rounded", "single"), if nil, use the default border style defined by 'vim.o.winborder'
+      -- border = nil, -- border style for the window (e.g. "rounded", "single"), if nil, use the default border style defined by 'vim.o.winborder'. See :h 'winborder' for more info.
       -- auto_install = false, -- if enabled, install missing parsers when editing a new file
       -- highlight = true, -- treesitter highlighting is enabled by default
       -- languages = {}, -- override or add new parser sources

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -13,6 +13,7 @@ local cfg = {
     ---@type table<string, string|{install_info?: {url: string, location?: string, revision?: string, branch?: string, generate?: boolean, use_repo_queries?: boolean}, requires?: string[]}>
     languages = {},
     ensure_installed = {},
+    border = nil,
     auto_install = false,
     highlight = true,
     nohighlight = {},
@@ -357,7 +358,7 @@ function M.open()
         width = w,
         height = h,
         style = "minimal",
-        border = "rounded",
+        border = cfg.border,
         row = math.floor((vim.o.lines - h) / 2),
         col = math.floor((vim.o.columns - w) / 2),
         title = footer,


### PR DESCRIPTION
Added a config option for a custom border. When set to nil, vim.api.nvim_open_win will use vim.o.winborder as a fallback.