### PR TITLE
docs: add luadocs for config

### DIFF
--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -2,10 +2,30 @@ local repos = require("tree-sitter-manager.repos")
 
 local M = {}
 
+---@class tree-sitter-manager.Config
+---@field parser_dir? string Directory to install compiled parsers into. Defaults to `stdpath('data')/site/parser`.
+---@field query_dir? string Directory to install query files into. Defaults to `stdpath('data')/site/queries`.
+---@field languages? table<string, string|tree-sitter-manager.LanguageSpec> User-defined language repos to use instead of the built-in ones. Can either be a string (a git URL), or a more detailed LanguageSpec.
+---@field ensure_installed? string[] Languages to install on `setup()` if not already present.
+---@field border? string|string[] Border style passed to `nvim_open_win` for the manager UI.
+---@field auto_install? boolean Install missing parsers automatically on `FileType`.
+---@field highlight? boolean|string[] Enable `vim.treesitter.start()` for installed parsers. `true` enables all, or pass a list of languages.
+---@field nohighlight? string[] Languages to disable highlighting for.
+
+---@class tree-sitter-manager.LanguageSpec
+---@field install_info? tree-sitter-manager.InstallInfo Information about how to fetch and build the grammar.
+---@field requires? string[] Other languages that are dependencies of this one and must be installed first.
+
+---@class tree-sitter-manager.InstallInfo
+---@field url string Git URL of the grammar repository.
+---@field location? string Sub-directory within the repo where the grammar is stored. Defaults to the name of the language.
+---@field revision? string Git revision to check out after cloning. Takes priority over `branch`.
+---@field branch? string Git branch to check out after cloning. Ignored if `revision` is set.
+---@field generate? boolean Run `tree-sitter generate` before building. Defaults to false.
+---@field use_repo_queries? boolean Use queries from the cloned repo's `queries/` directory instead of those bundled with the plugin. Defaults to false.
 M.cfg = {
     parser_dir = vim.fn.stdpath("data") .. "/site/parser",
     query_dir = vim.fn.stdpath("data") .. "/site/queries",
-    ---@type table<string, string|{install_info?: {url: string, location?: string, revision?: string, branch?: string, generate?: boolean, use_repo_queries?: boolean}, requires?: string[]}>
     languages = {},
     ensure_installed = {},
     border = nil,

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -23,6 +23,7 @@ local M = {}
 ---@field branch? string Git branch to check out after cloning. Ignored if `revision` is set.
 ---@field generate? boolean Run `tree-sitter generate` before building. Defaults to false.
 ---@field use_repo_queries? boolean Use queries from the cloned repo's `queries/` directory instead of those bundled with the plugin. Defaults to false.
+---@type tree-sitter-manager.Config
 M.cfg = {
     parser_dir = vim.fn.stdpath("data") .. "/site/parser",
     query_dir = vim.fn.stdpath("data") .. "/site/queries",


### PR DESCRIPTION
I've recently become fond of adding `@type` comments to my plugin configs in my lazy config so I can get autocomplete on the options. This PR adds a type definition for the built-in config type. 

I've done my best to work out what some of the undocumented options are, but if something's off (or should be left undocumented) please let me know!