### PR TITLE
ui: small improvement for the manager window

### DIFF
--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -5,6 +5,7 @@ local src = debug.getinfo(1, "S").source
 local abs = src:sub(1, 1) == "@" and vim.fn.fnamemodify(src:sub(2), ":p") or ""
 local PLUGIN_ROOT = abs ~= "" and vim.fn.fnamemodify(abs, ":h:h:h") or vim.fn.stdpath("config")
 
+local title = "🌳  Tree-sitter Parser Manager"
 local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [q] Close "
 
 local cfg = {
@@ -105,7 +106,10 @@ local function install_with_deps(lang, callback, installing)
         if not vim.uv.fs_stat(ppath(dep)) then
             vim.notify("📦 Installing dependency: " .. dep, vim.log.levels.INFO)
             install_with_deps(dep, function(ok)
-                if not ok then callback(false) return end
+                if not ok then
+                    callback(false)
+                    return
+                end
                 install_deps(i + 1)
             end, vim.deepcopy(installing))
         else
@@ -179,7 +183,8 @@ function M._install_single(lang, callback)
                     if info.use_repo_queries then
                         used_repo_queries = copy_queries_from_repo(lang, build_dir)
                         if not used_repo_queries then
-                            vim.notify("⚠ No queries/ found in repo for " .. lang .. ", falling back to bundled queries", 2)
+                            vim.notify("⚠ No queries/ found in repo for " .. lang .. ", falling back to bundled queries",
+                                2)
                         end
                     end
 
@@ -285,7 +290,7 @@ local function get_meta_suffix(lang)
 end
 
 local function render(buf)
-    local lines = { " 🌳  Tree-sitter Parser Manager ", " ────────────────────────────────" }
+    local lines = {}
     for _, l in ipairs(languages) do
         table.insert(lines, string.format("   %-12s  %s%s", l, get_status_icon(l), get_meta_suffix(l)))
     end
@@ -361,11 +366,13 @@ function M.open()
         width = w,
         height = h,
         style = "minimal",
-        border = cfg.border,
+        border = cfg.border or "rounded",
         row = math.floor((vim.o.lines - h) / 2),
         col = math.floor((vim.o.columns - w) / 2),
-        title = footer,
+        title = title,
         title_pos = "center",
+        footer = footer,
+        footer_pos = "center"
     })
     render(buf)
 


### PR DESCRIPTION
Hello! I have recently found this repository and it is exactly what I am looking for after the nvim-treesitter being archived.

I saw that the UI with the defaults values looks a bit weird, because with border nil the default for `winborder` is "none" which hides the title with the instructions:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/f9352a72-955c-4658-b7ca-2a0e1bf1eb15" />

My suggestion is to have a default border already set, and as personal preference I have added the instructions as the footer and the plugin name as the title, it would look something like this:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/50398016-0da2-4608-a8d5-11d16895c38f" />

I have added a rounded border as the default if cfg.border is nil, but any other kind of border can be set.
Let me know what do you think, and thank you for creating this plugin :)

