### PR TITLE
feat: add health.lua module for :checkhealth

### DIFF
--- a/lua/tree-sitter-manager/health.lua
+++ b/lua/tree-sitter-manager/health.lua
@@ -4,12 +4,22 @@ M.check = function()
     vim.health.start("tree-sitter-manager")
 
     -- Ensure dependencies are installed
-    if vim.fn.executable("tree-sitter") == 0 then
-        vim.health.error("tree-sitter CLI must be installed")
-    else
-        local version = vim.system({ "tree-sitter", "--version" }):wait()
-        local strip_trailing_newline = string.sub(version.stdout, 1, -2)
-        vim.health.ok("tree-sitter CLI is installed: " .. strip_trailing_newline)
+    local dependencies = {
+        -- Format is { command_name, human_readable_name }
+        { "tree-sitter", "the tree-sitter CLI" },
+        { "git", "git" },
+        { "cc", "a C compiler" },
+    }
+    for _, dependency in pairs(dependencies) do
+        local command_name = dependency[1]
+        local human_readable_name = dependency[2]
+        if vim.fn.executable(command_name) == 0 then
+            vim.health.error(human_readable_name .. " must be installed")
+        else
+            local version = vim.system({ command_name, "--version" }):wait()
+            local first_line = vim.fn.split(version.stdout, "\n")[1]
+            vim.health.ok(human_readable_name .. " is installed: " .. first_line)
+        end
     end
 
 end

--- a/lua/tree-sitter-manager/health.lua
+++ b/lua/tree-sitter-manager/health.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+M.check = function()
+    vim.health.start("tree-sitter-manager")
+
+    -- Ensure dependencies are installed
+    if vim.fn.executable("tree-sitter") == 0 then
+        vim.health.error("tree-sitter CLI must be installed")
+    else
+        local version = vim.system({ "tree-sitter", "--version" }):wait()
+        local strip_trailing_newline = string.sub(version.stdout, 1, -2)
+        vim.health.ok("tree-sitter CLI is installed: " .. strip_trailing_newline)
+    end
+
+end
+
+return M


### PR DESCRIPTION
I typically run through `:checkhealth` looking for problems whenever setting up nvim on a new machine. This PR adds a checkhealth reminder to install the tree-sitter CLI.

example:
<img width="1045" height="208" alt="image" src="https://github.com/user-attachments/assets/c4a410ec-18bc-4b21-93a3-263d8da6251e" />
