### PR TITLE
fix: check effective_repos instead of base_repos in install_new

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -177,7 +177,7 @@ function M.remove(lang)
 end
 
 function M.install_new(lang, verbose)
-    if not config.base_repos[lang] then
+    if not config.effective_repos[lang] then
         if verbose then
             vim.notify("⚠ Parser not found in repos: " .. lang, vim.log.levels.WARN)
         end


### PR DESCRIPTION
 Problem

  install_new was checking config.base_repos to validate a language, but base_repos only contains built-in parsers. User-defined languages added via the languages
  option were silently skipped by ensure_installed and auto_install.

  Fix

  Changed to check config.effective_repos, which is the merged result of base_repos and the user's languages config (set up in setup()). This has no impact on
  built-in languages since effective_repos fully contains base_repos.

  Related

  Related #48