### PR TITLE
feat: record installed parser SHA in lock.js

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -74,55 +74,58 @@ function M._install_single(lang, callback)
                 build_dir = tmp .. "/" .. location
             end
 
-            local function do_build()
-                vim.notify("🔨 Building " .. lang)
-                util.run_cmd({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_dir, function(build)
-                    if not build.ok then
-                        local err = build.output
-                        if #err > 500 then err = err:sub(-500) end
-                        vim.notify("Build failed for " .. lang .. ":\n" .. err, 3)
-                        vim.fn.delete(tmp, "rf")
-                        callback(false)
-                        return
-                    end
+            util.run_cmd({ "git", "rev-parse", "HEAD" }, tmp, function(sha_res)
+                local sha = sha_res.ok and sha_res.output:gsub("%s+", "") or nil
 
-                    local used_repo_queries = false
-                    if info.use_repo_queries then
-                        used_repo_queries = copy_queries_from_repo(lang, build_dir)
-                        if not used_repo_queries then
-                            vim.notify("⚠ No queries/ found in repo for " .. lang .. ", falling back to bundled queries", 2)
+                local function do_build()
+                    vim.notify("🔨 Building " .. lang)
+                    util.run_cmd({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_dir, function(build)
+                        if not build.ok then
+                            local err = build.output
+                            if #err > 500 then err = err:sub(-500) end
+                            vim.notify("Build failed for " .. lang .. ":\n" .. err, 3)
+                            vim.fn.delete(tmp, "rf")
+                            callback(false)
+                            return
                         end
-                    end
 
-                    if not used_repo_queries then
-                        copy_queries(lang, location)
-                    end
+                        local used_repo_queries = false
+                        if info.use_repo_queries then
+                            used_repo_queries = copy_queries_from_repo(lang, build_dir)
+                            if not used_repo_queries then
+                                vim.notify("⚠ No queries/ found in repo for " .. lang .. ", falling back to bundled queries", 2)
+                            end
+                        end
 
-                    util.run_cmd({ "git", "rev-parse", "HEAD" }, tmp, function(sha_res)
-                        if sha_res.ok then
-                            local sha = sha_res.output:gsub("%s+", "")
+                        if not used_repo_queries then
+                            copy_queries(lang, location)
+                        end
+
+                        vim.fn.delete(tmp, "rf")
+
+                        if sha then
                             util.lock_set(lang, { url = info.url, sha = sha })
                         end
-                        vim.fn.delete(tmp, "rf")
+
                         vim.notify("✓ " .. lang .. " installed")
                         callback(true)
                     end)
-                end)
-            end
+                end
 
-            if info.generate then
-                util.run_cmd({ "tree-sitter", "generate" }, build_dir, function(gen)
-                    if not gen.ok then
-                        vim.notify("Generate failed for " .. lang .. ":\n" .. gen.output:sub(1, 300), 3)
-                        vim.fn.delete(tmp, "rf")
-                        callback(false)
-                        return
-                    end
+                if info.generate then
+                    util.run_cmd({ "tree-sitter", "generate" }, build_dir, function(gen)
+                        if not gen.ok then
+                            vim.notify("Generate failed for " .. lang .. ":\n" .. gen.output:sub(1, 300), 3)
+                            vim.fn.delete(tmp, "rf")
+                            callback(false)
+                            return
+                        end
+                        do_build()
+                    end)
+                else
                     do_build()
-                end)
-            else
-                do_build()
-            end
+                end
+            end)
         end
 
         local ref = info.revision or info.branch

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -94,14 +94,19 @@ function M._install_single(lang, callback)
                         end
                     end
 
-                    vim.fn.delete(tmp, "rf")
-
                     if not used_repo_queries then
                         copy_queries(lang, location)
                     end
 
-                    vim.notify("✓ " .. lang .. " installed")
-                    callback(true)
+                    util.run_cmd({ "git", "rev-parse", "HEAD" }, tmp, function(sha_res)
+                        if sha_res.ok then
+                            local sha = sha_res.output:gsub("%s+", "")
+                            util.lock_set(lang, { url = info.url, sha = sha })
+                        end
+                        vim.fn.delete(tmp, "rf")
+                        vim.notify("✓ " .. lang .. " installed")
+                        callback(true)
+                    end)
                 end)
             end
 
@@ -173,6 +178,7 @@ function M.remove(lang)
     if vim.uv.fs_stat(util.ppath(lang)) then vim.uv.fs_unlink(util.ppath(lang)) end
     local qd = config.cfg.query_dir .. "/" .. lang
     if vim.uv.fs_stat(qd) then vim.fn.delete(qd, "rf") end
+    util.lock_remove(lang)
     vim.notify("✕ " .. lang)
 end
 

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -44,7 +44,7 @@ function M.copy_dir(src, dst)
 end
 
 local function lock_path()
-    return config.cfg.parser_dir .. "/lock.json"
+    return vim.fn.fnamemodify(config.cfg.parser_dir, ":h") .. "/lock.json"
 end
 
 function M.lock_read()
@@ -59,6 +59,7 @@ end
 
 function M.lock_write(data)
     local path = lock_path()
+    vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
     local fd = io.open(path, "w")
     if not fd then return end
     fd:write(M.json_pretty(data))

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -43,4 +43,42 @@ function M.copy_dir(src, dst)
     end
 end
 
+local function lock_path()
+    return config.cfg.parser_dir .. "/lock.json"
+end
+
+function M.lock_read()
+    local path = lock_path()
+    local fd = io.open(path, "r")
+    if not fd then return {} end
+    local content = fd:read("*a")
+    fd:close()
+    local ok, data = pcall(vim.json.decode, content)
+    return (ok and type(data) == "table") and data or {}
+end
+
+function M.lock_write(data)
+    local path = lock_path()
+    local fd = io.open(path, "w")
+    if not fd then return end
+    fd:write(vim.json.encode(data))
+    fd:close()
+end
+
+function M.lock_set(lang, entry)
+    local data = M.lock_read()
+    data[lang] = entry
+    M.lock_write(data)
+end
+
+function M.lock_remove(lang)
+    local data = M.lock_read()
+    data[lang] = nil
+    M.lock_write(data)
+end
+
+function M.lock_get(lang)
+    return M.lock_read()[lang]
+end
+
 return M

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -61,8 +61,24 @@ function M.lock_write(data)
     local path = lock_path()
     local fd = io.open(path, "w")
     if not fd then return end
-    fd:write(vim.json.encode(data))
+    fd:write(M.json_pretty(data))
     fd:close()
+end
+
+function M.json_pretty(data, indent)
+    indent = indent or ""
+    local next_indent = indent .. "  "
+    if type(data) ~= "table" then
+        return vim.json.encode(data)
+    end
+    local keys = vim.tbl_keys(data)
+    table.sort(keys)
+    if #keys == 0 then return "{}" end
+    local parts = {}
+    for _, k in ipairs(keys) do
+        table.insert(parts, next_indent .. vim.json.encode(k) .. ": " .. M.json_pretty(data[k], next_indent))
+    end
+    return "{\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "}"
 end
 
 function M.lock_set(lang, entry)

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -44,7 +44,7 @@ function M.copy_dir(src, dst)
 end
 
 local function lock_path()
-    return vim.fn.fnamemodify(config.cfg.parser_dir, ":h") .. "/lock.json"
+    return vim.fn.stdpath("config") .. "/tsm-lock.json"
 end
 
 function M.lock_read()


### PR DESCRIPTION
Part of #41. This is PR1 of 3 planned PRs for parser revision tracking.

Changes

 - Added lock file utilities to util.lua:
  - lock_set(lang, entry) — saves { url, sha } after installation
  - lock_remove(lang) — removes the entry on parser removal
  - lock_get(lang) — retrieves the entry (for future use in PR2/PR3)
 - After a successful build, git rev-parse HEAD is called to capture the installed commit SHA, which is written to lock.json
 - remove() now cleans up the corresponding lock entry
 - lock.json is stored in the parent of parser_dir (e.g. ~/.local/share/nvim/site/lock.json) to keep the parser directory clean

lock.json example

 {
   "lua": {
     "sha": "abc1234...",
     "url": "https://github.com/..."
   }
 }