### PR TITLE
docs(README): added instructions for `vim.pack` package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
 }
 ```
 
+### vim.pack
+```lua
+vim.pack.add {
+  { src = "https://github.com/romus204/tree-sitter-manager.nvim" }
+}
+
+require("tree-sitter-manager").setup({
+  -- Default Options
+  -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session
+  -- border = nil, -- border style for the window (e.g. "rounded", "single"), if nil, use the default border style defined by 'vim.o.winborder'. See :h 'winborder' for more info.
+  -- auto_install = false, -- if enabled, install missing parsers when editing a new file
+  -- highlight = true, -- treesitter highlighting is enabled by default
+  -- languages = {}, -- override or add new parser sources
+  -- parser_dir = vim.fn.stdpath("data") .. "/site/parser",
+  -- query_dir = vim.fn.stdpath("data") .. "/site/queries",
+})
+```
+
 ## Custom / Fork Repositories
 You can override built-in language definitions or add entirely new ones via the `languages`
 option in `setup()`. This keeps `repos.lua` clean — no changes to the plugin repository are


### PR DESCRIPTION
As this project targets nvim 0.12+, there is a built-in package manager available in neovim. Even though there is no specific name for this package manager, it is known as `vim.pack`. This commit adds instruction to install this plugin using `vim.pack`