### PR TITLE
Addition: Org Mode Parser

### DIFF
--- a/lua/tree-sitter-manager/repos.lua
+++ b/lua/tree-sitter-manager/repos.lua
@@ -1171,6 +1171,12 @@ return {
             url = 'https://github.com/tree-sitter-grammars/tree-sitter-odin',
         },
     },
+    org = {
+        install_info = {
+            revision = '219c0b27fdb2c0aeb43841f23f03d6f54657f288',
+            url = 'https://github.com/nvim-orgmode/tree-sitter-org',
+        }
+    },
     pascal = {
         install_info = {
             revision = '042119eca2e18a60e56317fb06ee3ba5c32cb447',


### PR DESCRIPTION
Adding [nvim-orgmode/tree-sitter-org](https://github.com/nvim-orgmode/tree-sitter-org) to `repos.lua`.

The native repo queries don't work for syntax highlighting or markup. Presumably, loading the [original plugin](https://github.com/nvim-orgmode/orgmode) would link the captures to a given highlight group. I'm going to see about adding some plugin-agnostic queries for this parser, then open another PR.

If you'd prefer to hold off on merging until some actually useful queries are defined for the parser, just let me know