### PR TITLE
feat: Support for queries directory options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ require("tree-sitter-manager").setup({
     mylang = {
       install_info = {
         url = "https://github.com/someone/tree-sitter-mylang",
+        queries = "queries/subdir", -- override the default "queries" source directory
         use_repo_queries = true, -- copy queries/ from the cloned repo
       },
     },
@@ -112,6 +113,8 @@ require("tree-sitter-manager").setup({
 
 If `use_repo_queries = true` but the repo has no `queries/` directory, a warning is shown
 and the plugin falls back to the bundled queries automatically.
+
+The default `queries/` directory can be changed by means of the optional `queries` field.
 
 ## Treesitter Highlighting
 Treesitter highlighting is enabled by default. If you prefer to use standard regex highlighting for specific languages, use the `nohighlight` option.
@@ -136,17 +139,17 @@ require("tree-sitter-manager").setup({
 `:TSManager` - Open the parser management interface
 
 ## Keybindings
-`i` - Install parser under cursor  
-`x` - Remove parser under cursor  
-`u` - Update parser under cursor  
-`r` - Refresh installation status  
-`q / <Esc>` - Close window  
+`i` - Install parser under cursor<br/>
+`x` - Remove parser under cursor<br/>
+`u` - Update parser under cursor<br/>
+`r` - Refresh installation status<br/>
+`q / <Esc>` - Close window<br/>
 
 ## Queries
 Syntax highlighting queries (highlights.scm, injections.scm, etc.) were sourced from the archived [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) repository and placed in `runtime/queries/`.
 
 ## Parser Repository Links
-Parser repository URLs in `repos.lua` are sourced from the archived [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) repository. 
+Parser repository URLs in `repos.lua` are sourced from the archived [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) repository.
 
 > [!WARNING]
 > These links are provided as-is. Due to the large number of parsers, each URL cannot be manually verified for current availability or compatibility. If you encounter a broken link, outdated revision, or build failure, please:

--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -212,12 +212,13 @@ Each entry has the following shape: >lua
   languages = {
     <lang> = {
       install_info = {
-        url             = "https://github.com/...",  -- required
-        location        = nil,    -- subdirectory inside the repo (optional)
-        revision        = nil,    -- commit SHA to pin (optional)
-        branch          = nil,    -- branch name (optional)
-        generate        = false,  -- run `tree-sitter generate` before build
-        use_repo_queries = false, -- copy queries/ from cloned repo
+        url              = "https://github.com/...",  -- required
+        location         = nil,       -- subdirectory inside the repo (optional)
+        revision         = nil,       -- commit SHA to pin (optional)
+        branch           = nil,       -- branch name (optional)
+        generate         = false,     -- run `tree-sitter generate` before build
+        queries          = "queries", -- folder in the cloned repo containing queries
+        use_repo_queries = false,     -- copy queries/ from cloned repo
       },
       requires = {},  -- list of language names that must be installed first
     },
@@ -244,6 +245,7 @@ Add a new language: >lua
       mylang = {
         install_info = {
           url = "https://github.com/someone/tree-sitter-mylang",
+          queries = "queries/subdir",
           use_repo_queries = true,
         },
       },
@@ -260,6 +262,9 @@ Add a new language: >lua
 
   If `use_repo_queries = true` but the repo has no `queries/` directory,
   a warning is shown and the plugin falls back to bundled queries.
+
+  The default `queries/` directory can be changed
+  by means of the optional `queries` field.
 
 ==============================================================================
 9. HIGHLIGHTING                           *tree-sitter-manager-highlighting*

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -23,6 +23,7 @@ local M = {}
 ---@field revision? string Git revision to check out after cloning. Takes priority over `branch`.
 ---@field branch? string Git branch to check out after cloning. Ignored if `revision` is set.
 ---@field generate? boolean Run `tree-sitter generate` before building. Defaults to false.
+---@field queries? string Specifies the directory in the cloned repo that contains the queries. Defaults to 'queries'.
 ---@field use_repo_queries? boolean Use queries from the cloned repo's `queries/` directory instead of those bundled with the plugin. Defaults to false.
 ---@type tree-sitter-manager.Config
 M.cfg = {

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -18,6 +18,7 @@ function M.get_repo_info(lang)
             revision = entry.install_info.revision,
             branch = entry.install_info.branch,
             generate = entry.install_info.generate,
+            queries = entry.install_info.queries or "queries",
             use_repo_queries = entry.install_info.use_repo_queries,
         }
     end
@@ -42,8 +43,8 @@ local function copy_queries(lang, location)
     end
 end
 
-local function copy_queries_from_repo(lang, build_dir)
-    local qs = build_dir .. "/queries"
+local function copy_queries_from_repo(lang, build_dir, queries_dir)
+    local qs = build_dir .. "/" .. queries_dir
     if vim.uv.fs_stat(qs) then
         util.copy_dir(qs, config.cfg.query_dir .. "/" .. lang)
         return true
@@ -105,10 +106,14 @@ function M._install_single(lang, callback)
 
                 local used_repo_queries = false
                 if info.use_repo_queries then
-                    used_repo_queries = copy_queries_from_repo(lang, build_dir)
+                    used_repo_queries = copy_queries_from_repo(lang, build_dir, info.queries)
                     if not used_repo_queries then
                         vim.notify(
-                            "⚠ No queries/ found in repo for " .. lang .. ", falling back to bundled queries",
+                            "⚠ No "
+                                .. info.queries
+                                .. "/ found in repo for "
+                                .. lang
+                                .. ", falling back to bundled queries",
                             2
                         )
                     end


### PR DESCRIPTION
Added a feature to support the `queries` field within `install_info`, like `nvim-treesitter` used to do.

This closes #53