### PR TITLE
fix(installer): use lang instead of location for bundled query copy

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -106,7 +106,7 @@ function M._install_single(lang, callback)
                     vim.fn.delete(tmp, "rf")
 
                     if not used_repo_queries then
-                        copy_queries(lang, location)
+                        copy_queries(lang, lang)
                     end
 
                     vim.notify("✓ " .. lang .. " installed")


### PR DESCRIPTION
Fixes #70

## Problem

When a parser's `install_info` has a `location` field (e.g. `terraform` uses `"dialects/terraform"`), `copy_queries` was called with that path as the source argument:

```lua
copy_queries(lang, location)
-- looks for: runtime/queries/dialects/terraform/  ← does not exist
```

The `fs_stat` guard silently swallows the failure, so no queries are copied and treesitter highlighting is inactive despite the parser binary being installed.

## Fix

Bundled queries always live at `runtime/queries/<lang>/`, so pass `lang` as the source:

```lua
copy_queries(lang, lang)
-- looks for: runtime/queries/terraform/  ← correct
```

This is consistent with the query-only install path at line 58 which already uses `(lang, lang)`.