### PR TITLE
fix: warn when bundled queries not found in copy_queries

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -39,6 +39,8 @@ local function copy_queries(lang, location)
     local d = config.cfg.query_dir .. "/" .. lang
     if vim.uv.fs_stat(s) then
         util.copy_dir(s, d)
+    else
+        vim.notify("⚠ No bundled queries found for " .. lang .. " (looked in: " .. s .. ")", vim.log.levels.WARN)
     end
 end
 


### PR DESCRIPTION
## Summary

- `copy_queries` silently did nothing when the source path didn't exist
- User saw `✓ installed` but no queries were copied, causing highlighting to fail with no diagnostic
- Now emits a `WARN` notification with the full source path so mismatches are immediately visible

Closes #71

## Test

Install any parser whose `install_info.location` doesn't match a bundled query directory (e.g. `terraform` with `location = "dialects/terraform"`). Before this fix: silent success, no queries copied. After: warning shown with the exact path that was missing.