### PR TITLE
feat: ensure_installed = "all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
   config = function()
     require("tree-sitter-manager").setup({
       -- Default Options
-      -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session
+      -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session. If set to "all", install all parsers.
       -- border = nil, -- border style for the window (e.g. "rounded", "single"), if nil, use the default border style defined by 'vim.o.winborder'. See :h 'winborder' for more info.
       -- auto_install = false, -- if enabled, install missing parsers when editing a new file
       -- highlight = true, -- treesitter highlighting is enabled by default
@@ -55,7 +55,7 @@ vim.pack.add {
 
 require("tree-sitter-manager").setup({
   -- Default Options
-  -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session
+  -- ensure_installed = {}, -- list of parsers to install at the start of a neovim session. If set to "all", install all parsers.
   -- border = nil, -- border style for the window (e.g. "rounded", "single"), if nil, use the default border style defined by 'vim.o.winborder'. See :h 'winborder' for more info.
   -- auto_install = false, -- if enabled, install missing parsers when editing a new file
   -- highlight = true, -- treesitter highlighting is enabled by default

--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -116,12 +116,13 @@ languages ~
 ------------------------------------------------------------------------------
                                     *tree-sitter-manager-opt-ensure_installed*
 ensure_installed ~
-  Type: `string[]`
+  Type: `string[]\string`
   Default: `{}`
 
   List of parsers to install automatically at startup (if not already
-  installed). >lua
+  installed). If set to "all", install all parsers. >lua
     ensure_installed = { "lua", "python", "rust" },
+    ensure_installed = "all",
 <
 
 ------------------------------------------------------------------------------

--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -116,7 +116,7 @@ languages ~
 ------------------------------------------------------------------------------
                                     *tree-sitter-manager-opt-ensure_installed*
 ensure_installed ~
-  Type: `string[]\string`
+  Type: `string[]|string`
   Default: `{}`
 
   List of parsers to install automatically at startup (if not already

--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -120,7 +120,7 @@ ensure_installed ~
   Default: `{}`
 
   List of parsers to install automatically at startup (if not already
-  installed). If set to "all", install all parsers. >lua
+  installed). If set to `"all"`, install all parsers. >lua
     ensure_installed = { "lua", "python", "rust" },
     ensure_installed = "all",
 <

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -8,7 +8,7 @@ local datapath = vim.fn.stdpath("data")
 ---@field parser_dir? string Directory to install compiled parsers into. Defaults to `stdpath('data')/site/parser`.
 ---@field query_dir? string Directory to install query files into. Defaults to `stdpath('data')/site/queries`.
 ---@field languages? table<string, string|tree-sitter-manager.LanguageSpec> User-defined language repos to use instead of the built-in ones. Can either be a string (a git URL), or a more detailed LanguageSpec.
----@field ensure_installed? string[] Languages to install on `setup()` if not already present.
+---@field ensure_installed? string|string[] Languages to install on `setup()` if not already present. Use `"all"` to install all languages.
 ---@field border? string|string[] Border style passed to `nvim_open_win` for the manager UI.
 ---@field auto_install? boolean Install missing parsers automatically on `FileType`.
 ---@field highlight? boolean|string[] Enable `vim.treesitter.start()` for installed parsers. `true` enables all, or pass a list of languages.

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -36,7 +36,13 @@ function M.setup(opts)
         vim.opt.rtp:prepend(query_parent)
     end
 
-    for _, lang in ipairs(state.cfg.ensure_installed or {}) do
+    local ensure_list = state.cfg.ensure_installed
+    if ensure_list == "all" then
+        ensure_list = state.languages
+    else
+        ensure_list = ensure_list or {}
+    end
+    for _, lang in ipairs(ensure_list) do
         installer.install_new(lang, true)
     end
 


### PR DESCRIPTION
This adds a feature from nvim-treesitter. Upon setting `ensure_installed` to `"all"`, all parsers are installed at startup.