### PR TITLE
Add ucode parser (OpenWrt scripting language)

### DIFF
--- a/lua/tree-sitter-manager/repos.lua
+++ b/lua/tree-sitter-manager/repos.lua
@@ -1893,6 +1893,20 @@ return {
             url = "https://github.com/ColinKennedy/tree-sitter-usd",
         },
     },
+    ucode = {
+        install_info = {
+            revision = "v0.3.0",
+            url = "https://github.com/m00qek/tree-sitter-ucode",
+        },
+        requires = { "ucode_tmpl" },
+    },
+    ucode_tmpl = {
+        install_info = {
+            location = "tmpl",
+            revision = "v0.3.0",
+            url = "https://github.com/m00qek/tree-sitter-ucode",
+        },
+    },
     uxntal = {
         install_info = {
             revision = "ad9b638b914095320de85d59c49ab271603af048",

--- a/plugin/filetypes.lua
+++ b/plugin/filetypes.lua
@@ -3,3 +3,10 @@ filetypes = require("tree-sitter-manager.filetypes")
 for lang, ft in pairs(filetypes) do
     vim.treesitter.language.register(lang, ft)
 end
+
+-- Extensions that Neovim does not detect natively.
+vim.filetype.add({
+    extension = {
+        uc = "ucode",
+    },
+})

--- a/plugin/filetypes.lua
+++ b/plugin/filetypes.lua
@@ -7,6 +7,22 @@ end
 -- Extensions that Neovim does not detect natively.
 vim.filetype.add({
     extension = {
-        uc = "ucode",
+        -- .uc is used by both ucode (plain code) and ucode_tmpl (templates).
+        -- Detect by content: if any line starts with a template tag opener
+        -- ({%, {{, {#) the file is a template, otherwise plain ucode.
+        uc = function(path)
+            local f = io.open(path, "r")
+            if f then
+                for line in f:lines() do
+                    if line:match("^%s*{[%%{#]") then
+                        f:close()
+                        return "ucode_tmpl"
+                    end
+                end
+                f:close()
+            end
+            return "ucode"
+        end,
+        utpl = "ucode_tmpl",
     },
 })

--- a/plugin/filetypes.lua
+++ b/plugin/filetypes.lua
@@ -10,16 +10,12 @@ vim.filetype.add({
         -- .uc is used by both ucode (plain code) and ucode_tmpl (templates).
         -- Detect by content: if any line starts with a template tag opener
         -- ({%, {{, {#) the file is a template, otherwise plain ucode.
-        uc = function(path)
-            local f = io.open(path, "r")
-            if f then
-                for line in f:lines() do
-                    if line:match("^%s*{[%%{#]") then
-                        f:close()
-                        return "ucode_tmpl"
-                    end
+        uc = function(path, bufnr)
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, 100, false)
+            for _, line in ipairs(lines) do
+                if line:match("^%s*{[%%{#]") then
+                    return "ucode_tmpl"
                 end
-                f:close()
             end
             return "ucode"
         end,

--- a/runtime/queries/ucode/highlights.scm
+++ b/runtime/queries/ucode/highlights.scm
@@ -1,0 +1,158 @@
+; Highlight queries for ucode.
+; Capture names follow the tree-sitter / nvim-treesitter standard.
+
+; -------------------------------------------------------------------------
+; Identifiers
+; -------------------------------------------------------------------------
+
+(identifier) @variable
+(property_identifier) @variable.member
+(shorthand_property_identifier) @variable.member
+(statement_identifier) @label
+
+; -------------------------------------------------------------------------
+; Built-in / special values
+; -------------------------------------------------------------------------
+
+(this) @variable.builtin
+[(true) (false)] @boolean
+(null) @constant.builtin
+
+; -------------------------------------------------------------------------
+; Comments
+; -------------------------------------------------------------------------
+
+(comment) @comment @spell
+
+; -------------------------------------------------------------------------
+; Shebang
+; -------------------------------------------------------------------------
+
+(hash_bang_line) @keyword.directive
+
+; -------------------------------------------------------------------------
+; Literals
+; -------------------------------------------------------------------------
+
+(number) @number
+
+(string) @string
+(string (escape_sequence) @string.escape)
+
+(template_string) @string
+(template_string (escape_sequence) @string.escape)
+(template_substitution "${" @punctuation.special)
+(template_substitution "}" @punctuation.special)
+
+(regex) @string.regexp
+
+; -------------------------------------------------------------------------
+; Functions — definitions
+; -------------------------------------------------------------------------
+
+(function_declaration
+  name: (identifier) @function)
+
+(function_expression
+  name: (identifier) @function)
+
+; Method-style object entries: { key: function() {} }  or  { key: () => {} }
+(pair
+  key: (property_identifier) @function.method
+  value: [(function_expression) (arrow_function)])
+
+; -------------------------------------------------------------------------
+; Functions — calls
+; -------------------------------------------------------------------------
+
+(call_expression
+  function: (identifier) @function.call)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method.call))
+
+; -------------------------------------------------------------------------
+; Parameters
+; -------------------------------------------------------------------------
+
+(formal_parameters (identifier) @variable.parameter)
+(rest_element (identifier) @variable.parameter)
+(arrow_function parameter: (identifier) @variable.parameter)
+
+; -------------------------------------------------------------------------
+; Keywords — conditional
+; -------------------------------------------------------------------------
+
+["if" "elif" "else" "endif"] @keyword.conditional
+["switch" "case" "default"] @keyword.conditional
+
+; -------------------------------------------------------------------------
+; Keywords — loops
+; -------------------------------------------------------------------------
+
+["for" "endfor" "while" "endwhile"] @keyword.repeat
+
+; -------------------------------------------------------------------------
+; Keywords — functions
+; -------------------------------------------------------------------------
+
+["function" "endfunction"] @keyword.function
+
+; -------------------------------------------------------------------------
+; Keywords — control
+; -------------------------------------------------------------------------
+
+"return" @keyword.return
+["break" "continue"] @keyword
+
+; -------------------------------------------------------------------------
+; Keywords — exceptions
+; -------------------------------------------------------------------------
+
+["try" "catch"] @keyword.exception
+
+; -------------------------------------------------------------------------
+; Keywords — modules
+; -------------------------------------------------------------------------
+
+["import" "export"] @keyword.import
+["as" "from"] @keyword.import
+
+; -------------------------------------------------------------------------
+; Keywords — storage / operators
+; -------------------------------------------------------------------------
+
+["const" "let"] @keyword.storage
+["delete" "in"] @keyword.operator
+
+; -------------------------------------------------------------------------
+; Operators
+; -------------------------------------------------------------------------
+
+[
+  "=" "+=" "-=" "*=" "/=" "%=" "**="
+  "^=" "&=" "|=" ">>=" "<<=" "&&=" "||=" "??="
+] @operator
+
+[
+  "+" "-" "*" "/" "%" "**"
+  "&" "|" "^" "~" "<<" ">>"
+  "!" "&&" "||" "??"
+  "==" "!=" "===" "!=="
+  "<" ">" "<=" ">="
+  "++" "--"
+  "=>"
+  "..."
+] @operator
+
+(optional_chain) @operator
+(ternary_expression "?" @operator)
+(ternary_expression ":" @operator)
+
+; -------------------------------------------------------------------------
+; Punctuation
+; -------------------------------------------------------------------------
+
+["," ";"] @punctuation.delimiter
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket

--- a/runtime/queries/ucode/locals.scm
+++ b/runtime/queries/ucode/locals.scm
@@ -1,0 +1,100 @@
+; Locals queries for ucode.
+; Used by editors for rename, go-to-definition, and scope-aware highlight.
+
+; -------------------------------------------------------------------------
+; Scopes
+; -------------------------------------------------------------------------
+
+(function_declaration) @local.scope
+(function_expression) @local.scope
+(arrow_function) @local.scope
+; statement_block provides block scoping for let/const
+(statement_block) @local.scope
+; for loops scope their initialiser variable(s) to the loop body
+(for_statement) @local.scope
+(for_alt_statement) @local.scope
+(for_in_statement) @local.scope
+(for_in_alt_statement) @local.scope
+; catch clause scopes its parameter to the handler body
+(catch_clause) @local.scope
+
+; -------------------------------------------------------------------------
+; Definitions — functions
+; -------------------------------------------------------------------------
+
+; Function declaration names belong to the enclosing scope so that
+; callers outside the function body can resolve them.
+(function_declaration
+  name: (identifier) @local.definition.function
+  (#set! definition.function.scope parent))
+
+; Named function expressions (let f = function foo() {}) keep their name
+; *inside* the expression scope — foo is only visible for self-recursion,
+; not to the surrounding block.  No (#set! parent) here.
+(function_expression
+  name: (identifier) @local.definition.function)
+
+; -------------------------------------------------------------------------
+; Definitions — variables
+; -------------------------------------------------------------------------
+
+(variable_declarator
+  name: (identifier) @local.definition.var)
+
+; -------------------------------------------------------------------------
+; Definitions — parameters
+; -------------------------------------------------------------------------
+
+(formal_parameters (identifier) @local.definition.parameter)
+(rest_element (identifier) @local.definition.parameter)
+(arrow_function parameter: (identifier) @local.definition.parameter)
+
+; catch clause binding
+(catch_clause
+  parameter: (identifier) @local.definition.var)
+
+; -------------------------------------------------------------------------
+; Definitions — for-in loop variables
+;
+; Only capture when let/const is present (kind field exists).  A bare
+; `for (k in obj)` is an assignment to an existing variable, not a new
+; binding; tagging it as a definition would incorrectly shadow the outer `k`.
+; -------------------------------------------------------------------------
+
+(for_in_statement
+  kind: _
+  left: (identifier) @local.definition.var)
+(for_in_statement
+  kind: _
+  value: (identifier) @local.definition.var)
+(for_in_alt_statement
+  kind: _
+  left: (identifier) @local.definition.var)
+(for_in_alt_statement
+  kind: _
+  value: (identifier) @local.definition.var)
+
+; -------------------------------------------------------------------------
+; Definitions — imports
+; -------------------------------------------------------------------------
+
+; import def from "./mod.uc"
+(import_clause (identifier) @local.definition.import)
+
+; import * as ns from "./mod.uc"
+(namespace_import (identifier) @local.definition.import)
+
+; import { a } from "./mod.uc"  — name IS the local binding (no alias)
+(import_specifier
+  name: (identifier) @local.definition.import
+  !alias)
+
+; import { a as x } from "./mod.uc"  — only the alias is the local binding
+(import_specifier
+  alias: (identifier) @local.definition.import)
+
+; -------------------------------------------------------------------------
+; References
+; -------------------------------------------------------------------------
+
+(identifier) @local.reference

--- a/runtime/queries/ucode/tags.scm
+++ b/runtime/queries/ucode/tags.scm
@@ -1,0 +1,91 @@
+; Tags queries for ucode.
+; Used by GitHub code navigation and tools that index symbol definitions.
+
+; -------------------------------------------------------------------------
+; Function definitions — named declarations (brace body or endfunction body)
+; -------------------------------------------------------------------------
+
+(
+  (comment)* @doc
+  .
+  (function_declaration
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+; -------------------------------------------------------------------------
+; Function definitions — named function expressions
+; -------------------------------------------------------------------------
+
+(
+  (comment)* @doc
+  .
+  (function_expression
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+; -------------------------------------------------------------------------
+; Function definitions — let/const assigned a function or arrow
+; -------------------------------------------------------------------------
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(function_expression) (arrow_function)])) @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+; -------------------------------------------------------------------------
+; Function definitions — assignment of function to variable or property
+; -------------------------------------------------------------------------
+
+(assignment_expression
+  left: [
+    (identifier) @name
+    (member_expression
+      property: (property_identifier) @name)
+  ]
+  right: [(function_expression) (arrow_function)]) @definition.function
+
+; -------------------------------------------------------------------------
+; Function definitions — object method pairs  { key: function() {} }
+; -------------------------------------------------------------------------
+
+(pair
+  key: (property_identifier) @name
+  value: [(function_expression) (arrow_function)]) @definition.function
+
+; -------------------------------------------------------------------------
+; Constants — exported scalar / expression values
+; -------------------------------------------------------------------------
+
+(export_statement
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [
+        (number) (string) (true) (false) (null)
+        (identifier) (binary_expression) (call_expression)
+      ])) @definition.constant)
+
+; -------------------------------------------------------------------------
+; References — function calls
+; -------------------------------------------------------------------------
+
+(
+  (call_expression
+    function: (identifier) @name) @reference.call
+  (#not-match? @name "^(require|include|render)$")
+)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @name)
+  arguments: (_) @reference.call)

--- a/runtime/queries/ucode_tmpl/highlights.scm
+++ b/runtime/queries/ucode_tmpl/highlights.scm
@@ -1,0 +1,23 @@
+; Highlight queries for ucode_tmpl.
+; Template structure is styled here; ucode code inside tags is highlighted
+; via language injection (see injections.scm).
+
+; -------------------------------------------------------------------------
+; Tag delimiters
+; -------------------------------------------------------------------------
+
+[
+  "{%"  "%}"
+  "{%-" "-%}"
+  "{%+"
+  "{{"  "}}"
+  "{{-" "-}}"
+  "{#"  "#}"
+  "{#-" "-#}"
+] @keyword
+
+; -------------------------------------------------------------------------
+; Template comments
+; -------------------------------------------------------------------------
+
+(comment_tag) @comment @spell

--- a/runtime/queries/ucode_tmpl/injections.scm
+++ b/runtime/queries/ucode_tmpl/injections.scm
@@ -1,0 +1,8 @@
+; Injection queries for ucode_tmpl.
+; Instructs editors to parse code/expression block content as ucode.
+
+((statement_tag (code) @injection.content)
+ (#set! injection.language "ucode"))
+
+((expression_tag (code) @injection.content)
+ (#set! injection.language "ucode"))

--- a/runtime/queries/ucode_tmpl/locals.scm
+++ b/runtime/queries/ucode_tmpl/locals.scm
@@ -1,0 +1,3 @@
+; Locals queries for ucode_tmpl.
+; Variable definitions and references inside code blocks are handled by
+; the injected ucode grammar; nothing additional is needed here.


### PR DESCRIPTION
Adds support for [ucode](https://github.com/jow-/ucode), a JavaScript-like scripting language used in OpenWrt firmware.

The parser is split into two grammars hosted in [m00qek/tree-sitter-ucode](https://github.com/m00qek/tree-sitter-ucode):

- `ucode` — the main language (pinned to v0.1.2)
- `ucode_tmpl` — a template dialect, installed automatically as a dependency

**Changes:**
- Register `ucode` and `ucode_tmpl` in `repos.lua`
- `ucode` declares `requires = { "ucode_tmpl" }` so both parsers are installed together
