### PR TITLE
config: make nerdfont usage optional via a config flag

### DIFF
--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -5,7 +5,7 @@ License:  MIT
 Homepage: https://github.com/romus204/tree-sitter-manager.nvim
 
 ==============================================================================
-CONTENTS                                       *tree-sitter-manager-contents*
+CONTENTS                                      *tree-sitter-manager-contents*
 
   1. Introduction .............. |tree-sitter-manager-introduction|
   2. Requirements .............. |tree-sitter-manager-requirements|
@@ -158,7 +158,7 @@ highlight ~
 <
 
 ------------------------------------------------------------------------------
-                                        *tree-sitter-manager-opt-nohighlight*
+                                         *tree-sitter-manager-opt-nohighlight*
 nohighlight ~
   Type: `string[]`
   Default: `{}`
@@ -168,6 +168,15 @@ nohighlight ~
   preferred. >lua
     nohighlight = { "yaml", "zsh" },
 <
+
+------------------------------------------------------------------------------
+                                            *tree-sitter-manager-opt-nerdfont*
+nerdfont ~
+  Type: `boolean`
+  Default: `true`
+
+  By default, the manager buffer requires Nerd Fonts for emojis and icons. If
+  you prefer plain text instead of the glyphs set this to `false`.
 
 ==============================================================================
 6. COMMANDS                                   *tree-sitter-manager-commands*
@@ -290,11 +299,11 @@ Disable completely: >lua
 <
 
 ==============================================================================
-10. API                                          *tree-sitter-manager-api*
+10. API                                            *tree-sitter-manager-api*
 
 These functions are exposed on the module returned by `require()`.
 
-                                               *tree-sitter-manager.open()*
+                                                   *tree-sitter-manager.open()*
 `require("tree-sitter-manager").open()`
   Open the `:TSManager` TUI window programmatically.
 

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -13,6 +13,7 @@ local datapath = vim.fn.stdpath("data")
 ---@field auto_install? boolean Install missing parsers automatically on `FileType`.
 ---@field highlight? boolean|string[] Enable `vim.treesitter.start()` for installed parsers. `true` enables all, or pass a list of languages.
 ---@field nohighlight? string[] Languages to disable highlighting for.
+---@field nerdfont? boolean Enable nerdfont glyphs..
 
 ---@class tree-sitter-manager.LanguageSpec
 ---@field install_info? tree-sitter-manager.InstallInfo Information about how to fetch and build the grammar.
@@ -36,6 +37,7 @@ M.cfg = {
     auto_install = false,
     highlight = true,
     nohighlight = {},
+    nerdfont = true,
 }
 
 M.base_repos = repos

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -13,7 +13,7 @@ local datapath = vim.fn.stdpath("data")
 ---@field auto_install? boolean Install missing parsers automatically on `FileType`.
 ---@field highlight? boolean|string[] Enable `vim.treesitter.start()` for installed parsers. `true` enables all, or pass a list of languages.
 ---@field nohighlight? string[] Languages to disable highlighting for.
----@field nerdfont? boolean Enable nerdfont glyphs..
+---@field nerdfont? boolean Enable nerdfont glyphs.
 
 ---@class tree-sitter-manager.LanguageSpec
 ---@field install_info? tree-sitter-manager.InstallInfo Information about how to fetch and build the grammar.

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -2,10 +2,10 @@ local config = require("tree-sitter-manager.config")
 local util = require("tree-sitter-manager.util")
 local installer = require("tree-sitter-manager.installer")
 
-local glyph_icon = {"*", "🌳"}
-local glyph_ok = {"OK", "✅"}
-local glyph_warn = {"!!", "⚠️"}
-local glyph_fail = {"..", "❌"}
+local glyph_icon = { "*", "🌳" }
+local glyph_ok = { "OK", "✅" }
+local glyph_warn = { "!!", "⚠️" }
+local glyph_fail = { "..", "❌" }
 local glyph_index = 2
 
 local title = " Tree-sitter Parser Manager"

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -66,7 +66,7 @@ end
 function M.open()
     local max_w = #footer
     for _, l in ipairs(config.languages) do
-        max_w = math.max(max_w, #("   " .. l .. "  X  abc1234  requires:x,y"))
+        max_w = math.max(max_w, #("   " .. l .. "  XX  abc1234  requires:x,y"))
     end
     local w = math.max(max_w + 4, 40)
     local h = math.min(#config.languages + 6, vim.o.lines - 15)

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -2,7 +2,13 @@ local config = require("tree-sitter-manager.config")
 local util = require("tree-sitter-manager.util")
 local installer = require("tree-sitter-manager.installer")
 
-local title = "🌳 Tree-sitter Parser Manager"
+local glyph_icon = {"*", "🌳"}
+local glyph_ok = {"OK", "✅"}
+local glyph_warn = {"!!", "⚠️"}
+local glyph_fail = {"..", "❌"}
+local glyph_index = 2
+
+local title = " Tree-sitter Parser Manager"
 local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [q] Close "
 
 local M = {}
@@ -10,27 +16,27 @@ local M = {}
 local function get_status_icon(lang)
     if installer.is_only_query(lang) then
         if not vim.uv.fs_stat(util.qpath(lang)) then
-            return "❌"
+            return glyph_fail[glyph_index]
         end
     else
         if not vim.uv.fs_stat(util.ppath(lang)) then
-            return "❌"
+            return glyph_fail[glyph_index]
         end
     end
 
     for _, dep in ipairs(installer.get_requires(lang)) do
         if installer.is_only_query(dep) then
             if not vim.uv.fs_stat(util.qpath(dep)) then
-                return "⚠️"
+                return glyph_warn[glyph_index]
             end
         else
             if not vim.uv.fs_stat(util.ppath(dep)) then
-                return "⚠️"
+                return glyph_warn[glyph_index]
             end
         end
     end
 
-    return "✅"
+    return glyph_ok[glyph_index]
 end
 
 local function get_meta_suffix(lang)
@@ -49,7 +55,7 @@ end
 function M.render(buf)
     local lines = {}
     for _, l in ipairs(config.languages) do
-        table.insert(lines, string.format("   %-12s  %s%s", l, get_status_icon(l), get_meta_suffix(l)))
+        table.insert(lines, string.format("   %-18s  %s%s", l, get_status_icon(l), get_meta_suffix(l)))
     end
 
     vim.bo[buf].modifiable = true
@@ -60,10 +66,12 @@ end
 function M.open()
     local max_w = #footer
     for _, l in ipairs(config.languages) do
-        max_w = math.max(max_w, #("   " .. l .. "  ✅  abc1234  requires:x,y"))
+        max_w = math.max(max_w, #("   " .. l .. "  X  abc1234  requires:x,y"))
     end
     local w = math.max(max_w + 4, 40)
     local h = math.min(#config.languages + 6, vim.o.lines - 15)
+
+    glyph_index = config.cfg.nerdfont and 2 or 1
 
     local buf = vim.api.nvim_create_buf(false, true)
     local win = vim.api.nvim_open_win(buf, true, {
@@ -74,7 +82,7 @@ function M.open()
         border = config.cfg.border or "rounded",
         row = math.floor((vim.o.lines - h) / 2),
         col = math.floor((vim.o.columns - w) / 2),
-        title = title,
+        title = glyph_icon[glyph_index] .. title,
         title_pos = "center",
         footer = footer,
         footer_pos = "center",


### PR DESCRIPTION
As an alternative, a classic text-representation is used if Nerdfont flag is not set. Flag is enabled by default (to keep original behavior).

This ensure user without Nerdfont are able to read the output :)

`nerdfont = true`
<img width="525" height="298" alt="image" src="https://github.com/user-attachments/assets/9ed81482-4cd1-4d59-a320-9f026a3d06c2" />

`nerdfont = false`
<img width="526" height="392" alt="image" src="https://github.com/user-attachments/assets/2e703ae3-e2bc-4439-931e-a0b190b25565" />
