### PR TITLE
refactor(util): move some functions from installer to util

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -3,49 +3,16 @@ local util = require("tree-sitter-manager.util")
 
 local M = {}
 
-function M.get_repo_info(lang)
-    local entry = config.effective_repos[lang]
-    if not entry then
-        return nil
-    end
-    if type(entry) == "string" then
-        return { url = entry, location = lang }
-    end
-    if entry.install_info then
-        return {
-            url = entry.install_info.url,
-            location = entry.install_info.location,
-            revision = entry.install_info.revision,
-            branch = entry.install_info.branch,
-            generate = entry.install_info.generate,
-            queries = entry.install_info.queries or "queries",
-            use_repo_queries = entry.install_info.use_repo_queries,
-        }
-    end
-    return nil
-end
-
-function M.get_requires(lang)
-    local entry = config.effective_repos[lang]
-    return (type(entry) == "table" and entry.requires) or {}
-end
-
-function M.is_only_query(lang)
-    local info = M.get_repo_info(lang)
-    return not info or not info.url
-end
-
-local function copy_queries(lang, query_dir, build_path)
+local function copy_queries(lang, source)
     local bundled = vim.fs.joinpath(util.PLUGIN_ROOT, "runtime/queries", lang)
-    local source = bundled
-    if query_dir then
-        source = vim.fs.joinpath(build_path, query_dir)
+    source = source or bundled
+    if source then
         if not vim.uv.fs_stat(source) then
-            source = bundled
             vim.notify(
-                "⚠ No " .. query_dir .. "/ found for " .. lang .. ", falling back to bundled queries",
+                "⚠ " .. source .. " not found for " .. lang .. ", falling back to bundled queries",
                 vim.log.levels.WARN
             )
+            source = bundled
         end
     end
     util.copy_dir(source, util.qpath(lang))
@@ -61,17 +28,22 @@ local function treesitter_build(lang, query_dir, build_path, generate)
         ok = util.run({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_path)
     end
     if ok then
-        copy_queries(lang, query_dir, build_path)
-        vim.notify("✓ Installed  " .. lang)
+        copy_queries(lang, vim.fs.joinpath(build_path, query_dir))
     end
     return ok
 end
 
 function M._install_single(lang, callback)
-    callback = callback or function() end -- backward compatibility API
-    if M.is_only_query(lang) then
+    local _callback = callback or function() end
+    callback = function(ok)
+        if ok then
+            vim.notify("✓ Installed  " .. lang)
+        end
+        _callback(ok)
+    end
+
+    if util.is_only_query(lang) then
         copy_queries(lang)
-        vim.notify("✓ Installed  " .. lang)
         callback(true)
         return
     end
@@ -87,7 +59,7 @@ function M._install_single(lang, callback)
     local minor = tonumber(version[2])
     local patch = tonumber(version[3])
 
-    local info = M.get_repo_info(lang)
+    local info = util.get_repo_info(lang)
     local tmpdir = vim.fn.tempname()
     local build_path = vim.fs.joinpath(tmpdir, info.location)
 
@@ -135,14 +107,14 @@ local function install_with_deps(lang, callback, installing)
     end
     installing[lang] = true
 
-    local deps = M.get_requires(lang)
+    local deps = util.get_requires(lang)
     local function install_deps(i)
         if i > #deps then
             M._install_single(lang, callback)
             return
         end
         local dep = deps[i]
-        if not vim.uv.fs_stat(util.ppath(dep)) then
+        if not util.is_installed(dep) then
             vim.notify("📦 Installing dependency: " .. dep, vim.log.levels.INFO)
             install_with_deps(dep, function(ok)
                 if not ok then
@@ -163,13 +135,8 @@ function M.install(lang, callback)
 end
 
 function M.remove(lang)
-    if vim.uv.fs_stat(util.ppath(lang)) then
-        vim.uv.fs_unlink(util.ppath(lang))
-    end
-    local qd = vim.fs.joinpath(config.cfg.query_dir, lang)
-    if vim.uv.fs_stat(qd) then
-        vim.fn.delete(qd, "rf")
-    end
+    vim.fs.rm(util.ppath(lang), { recursive = true, force = true })
+    vim.fs.rm(util.qpath(lang), { recursive = true, force = true })
     vim.notify("✕ " .. lang)
 end
 
@@ -178,16 +145,7 @@ function M.install_new(lang, verbose)
         if verbose then
             vim.notify("⚠ Parser not found in repos: " .. lang, vim.log.levels.WARN)
         end
-        return
-    end
-
-    local installed = false
-    if M.is_only_query(lang) then
-        installed = vim.uv.fs_stat(util.qpath(lang)) ~= nil
-    else
-        installed = vim.uv.fs_stat(util.ppath(lang)) ~= nil
-    end
-    if not installed then
+    elseif not util.is_installed(lang) then
         M.install(lang)
     end
 end

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -8,25 +8,13 @@ local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [q] Close "
 local M = {}
 
 local function get_status_icon(lang)
-    if installer.is_only_query(lang) then
-        if not vim.uv.fs_stat(util.qpath(lang)) then
-            return "❌"
-        end
-    else
-        if not vim.uv.fs_stat(util.ppath(lang)) then
-            return "❌"
-        end
+    if not util.is_installed(lang) then
+        return "❌"
     end
 
-    for _, dep in ipairs(installer.get_requires(lang)) do
-        if installer.is_only_query(dep) then
-            if not vim.uv.fs_stat(util.qpath(dep)) then
-                return "⚠️"
-            end
-        else
-            if not vim.uv.fs_stat(util.ppath(dep)) then
-                return "⚠️"
-            end
+    for _, dep in ipairs(util.get_requires(lang)) do
+        if not util.is_installed(dep) then
+            return "⚠️"
         end
     end
 
@@ -34,12 +22,12 @@ local function get_status_icon(lang)
 end
 
 local function get_meta_suffix(lang)
-    local info = installer.get_repo_info(lang)
+    local info = util.get_repo_info(lang)
     local parts = {}
     if info and info.revision then
         table.insert(parts, string.sub(info.revision, 1, 7))
     end
-    local reqs = installer.get_requires(lang)
+    local reqs = util.get_requires(lang)
     if #reqs > 0 then
         table.insert(parts, "requires:" .. table.concat(reqs, ","))
     end

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -12,11 +12,54 @@ function M.ext()
     return sys:match("Windows") and ".dll" or sys:match("Darwin") and ".dylib" or ".so"
 end
 
-function M.ppath(l)
-    return vim.fs.joinpath(config.cfg.parser_dir, l .. M.ext())
+function M.ppath(lang)
+    return vim.fs.joinpath(config.cfg.parser_dir, lang .. M.ext())
 end
-function M.qpath(l)
-    return vim.fs.joinpath(config.cfg.query_dir, l)
+
+function M.qpath(lang)
+    return vim.fs.joinpath(config.cfg.query_dir, lang)
+end
+
+function M.get_requires(lang)
+    local entry = config.effective_repos[lang]
+    return (type(entry) == "table" and entry.requires) or {}
+end
+
+function M.get_repo_info(lang)
+    local entry = config.effective_repos[lang]
+    if not entry then
+        return nil
+    end
+    if type(entry) == "string" then
+        return { url = entry, location = lang }
+    end
+    if entry.install_info then
+        return {
+            url = entry.install_info.url,
+            location = entry.install_info.location,
+            revision = entry.install_info.revision,
+            branch = entry.install_info.branch,
+            generate = entry.install_info.generate,
+            queries = entry.install_info.queries or "queries",
+            use_repo_queries = entry.install_info.use_repo_queries,
+        }
+    end
+    return nil
+end
+
+function M.is_only_query(lang)
+    local info = M.get_repo_info(lang)
+    return not info or not info.url
+end
+
+function M.is_installed(lang)
+    local path
+    if M.is_only_query(lang) then
+        path = M.qpath(lang)
+    else
+        path = M.ppath(lang)
+    end
+    return nil ~= vim.uv.fs_stat(path)
 end
 
 function M.run(args, cwd)


### PR DESCRIPTION
Moved functions:
- get_requires
- get_repo_info
- is_only_query

Added functions:
- is_installed

Other changes:
- copy_queries expects a single `source` path
- put `vim.notify("Installed")` into the callback