### PR TITLE
fix: clear query cache after successful installation

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -38,6 +38,7 @@ function M._install_single(lang, callback)
     callback = function(ok)
         if ok then
             vim.notify("✓ Installed  " .. lang)
+            vim.treesitter.query.get:clear()
         end
         _callback(ok)
     end


### PR DESCRIPTION
Without clearing the cache, I had to restart the session for the new queries to take effect. With this queries are updated without restarting Neovim.