### PR TITLE
feat: add assume_installed option

### DIFF
--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -114,6 +114,19 @@ languages ~
   See |tree-sitter-manager-custom-repos| for details.
 
 ------------------------------------------------------------------------------
+                                    *tree-sitter-manager-opt-assume_installed*
+assume_installed ~
+  Type: `table`
+  Default: `{}`
+
+  Languages in this list are assumed to be installed. The following will tell
+  tree-sitter-manager to never install Neovim's built-in parsers: >lua
+    assume_installed = {
+      "c", "lua", "markdown", "markdown_inline", "query", "vim", "vimdoc"
+    }
+<
+
+------------------------------------------------------------------------------
                                     *tree-sitter-manager-opt-ensure_installed*
 ensure_installed ~
   Type: `string[]|string`

--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -71,6 +71,7 @@ vim-plug: >vim
 >lua
   require("tree-sitter-manager").setup({
     languages      = {},
+    assume_installed = {},
     ensure_installed = {},
     border         = nil,
     auto_install   = false,
@@ -125,6 +126,8 @@ assume_installed ~
       "c", "lua", "markdown", "markdown_inline", "query", "vim", "vimdoc"
     }
 <
+  Note: tree-sitter-manager parsers often ship with more query files than
+  what's available in Neovim.
 
 ------------------------------------------------------------------------------
                                     *tree-sitter-manager-opt-ensure_installed*

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -8,6 +8,7 @@ local datapath = vim.fn.stdpath("data")
 ---@field parser_dir? string Directory to install compiled parsers into. Defaults to `stdpath('data')/site/parser`.
 ---@field query_dir? string Directory to install query files into. Defaults to `stdpath('data')/site/queries`.
 ---@field languages? table<string, string|tree-sitter-manager.LanguageSpec> User-defined language repos to use instead of the built-in ones. Can either be a string (a git URL), or a more detailed LanguageSpec.
+---@field assume_installed? string[] Languages to never install.
 ---@field ensure_installed? string|string[] Languages to install on `setup()` if not already present. Use `"all"` to install all languages.
 ---@field border? string|string[] Border style passed to `nvim_open_win` for the manager UI.
 ---@field auto_install? boolean Install missing parsers automatically on `FileType`.
@@ -32,6 +33,7 @@ M.cfg = {
     parser_dir = vim.fs.joinpath(datapath, "site/parser"),
     query_dir = vim.fs.joinpath(datapath, "site/queries"),
     languages = {},
+    assume_installed = {},
     ensure_installed = {},
     border = nil,
     auto_install = false,

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -43,13 +43,13 @@ function M.setup(opts)
         ensure_list = ensure_list or {}
     end
     for _, lang in ipairs(ensure_list) do
-        installer.install_new(lang, true)
+        installer.install(lang)
     end
 
     if state.cfg.auto_install then
         vim.api.nvim_create_autocmd("FileType", {
             callback = function(a)
-                installer.install_new(a.match)
+                installer.install(a.match)
             end,
         })
     end
@@ -82,7 +82,7 @@ function M.setup(opts)
 
     vim.api.nvim_create_user_command("TSInstall", function(args)
         for _, lang in ipairs(args.fargs) do
-            installer.install_new(lang, true)
+            installer.install(lang)
         end
     end, {
         nargs = "+",

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -132,23 +132,17 @@ local function install_with_deps(lang, callback, installing)
     install_deps(1)
 end
 
-function M.install(lang, callback)
-    install_with_deps(lang, callback)
-end
-
 function M.remove(lang)
     vim.fs.rm(util.ppath(lang), { recursive = true, force = true })
     vim.fs.rm(util.qpath(lang), { recursive = true, force = true })
     vim.notify("✕ " .. lang)
 end
 
-function M.install_new(lang, verbose)
+function M.install(lang, callback)
     if not config.effective_repos[lang] then
-        if verbose then
-            vim.notify("⚠ Parser not found in repos: " .. lang, vim.log.levels.WARN)
-        end
+        vim.notify("⚠ Parser not found in repos: " .. lang, vim.log.levels.WARN)
     elseif not util.is_installed(lang) then
-        M.install(lang)
+        install_with_deps(lang, callback)
     end
 end
 

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -56,9 +56,9 @@ function M.is_installed(lang)
     if vim.list_contains(config.cfg.assume_installed, lang) then
         return true
     elseif M.is_only_query(lang) then
-        return vim.uv.fs_stat(M.qpath(lang))
+        return nil ~= vim.uv.fs_stat(M.qpath(lang))
     else
-        return vim.uv.fs_stat(M.ppath(lang))
+        return nil ~= vim.uv.fs_stat(M.ppath(lang))
     end
 end
 

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -53,13 +53,13 @@ function M.is_only_query(lang)
 end
 
 function M.is_installed(lang)
-    local path
-    if M.is_only_query(lang) then
-        path = M.qpath(lang)
+    if vim.list_contains(config.cfg.assume_installed, lang) then
+        return true
+    elseif M.is_only_query(lang) then
+        return vim.uv.fs_stat(M.qpath(lang))
     else
-        path = M.ppath(lang)
+        return vim.uv.fs_stat(M.ppath(lang))
     end
-    return nil ~= vim.uv.fs_stat(path)
 end
 
 function M.run(args, cwd)


### PR DESCRIPTION
Example: use Neovim's built-in parsers for `c` and `vim`
```lua
require('tree-sitter-manager').setup({
  assume_installed = { 'c', 'vim' }
})
```

NOTE: this requires `install` to always check if the parser is installed. `install_new` is no longer needed.

Closes #65 