### PR TITLE
UI: fix spacing in manager title, respect vim.o.winborder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Although Neovim 0.12 integrated Tree-sitter into the core, it still lacks a buil
       -- auto_install = false, -- if enabled, install missing parsers when editing a new file
       -- highlight = true, -- treesitter highlighting is enabled by default
       -- languages = {}, -- override or add new parser sources
+      -- nerdfont = true, -- use Nerd Font icons in the manager UI
     })
   end
 }
@@ -60,6 +61,7 @@ require("tree-sitter-manager").setup({
   -- auto_install = false, -- if enabled, install missing parsers when editing a new file
   -- highlight = true, -- treesitter highlighting is enabled by default
   -- languages = {}, -- override or add new parser sources
+  -- nerdfont = true, -- use Nerd Font icons in the manager UI
 })
 ```
 

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -67,7 +67,7 @@ function M.open()
         width = w,
         height = h,
         style = "minimal",
-        border = config.cfg.border or vim.o.winborder,
+        border = config.cfg.border,
         row = math.floor((vim.o.lines - h) / 2),
         col = math.floor((vim.o.columns - w) / 2),
         title = "   " .. glyph_icon[glyph_index] .. " " .. title .. "   ",

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -8,7 +8,7 @@ local glyph_warn = { "!!", "⚠️" }
 local glyph_fail = { "..", "❌" }
 local glyph_index = 2
 
-local title = " Tree-sitter Parser Manager"
+local title = "Tree-sitter Parser Manager"
 local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [q] Close "
 
 local M = {}
@@ -67,10 +67,10 @@ function M.open()
         width = w,
         height = h,
         style = "minimal",
-        border = config.cfg.border or "rounded",
+        border = config.cfg.border or vim.o.winborder,
         row = math.floor((vim.o.lines - h) / 2),
         col = math.floor((vim.o.columns - w) / 2),
-        title = glyph_icon[glyph_index] .. title,
+        title = "   " .. glyph_icon[glyph_index] .. " " .. title .. "   ",
         title_pos = "center",
         footer = footer,
         footer_pos = "center",

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -70,7 +70,7 @@ function M.open()
         border = config.cfg.border,
         row = math.floor((vim.o.lines - h) / 2),
         col = math.floor((vim.o.columns - w) / 2),
-        title = "   " .. glyph_icon[glyph_index] .. " " .. title .. "   ",
+        title = " " .. glyph_icon[glyph_index] .. " " .. title .. " ",
         title_pos = "center",
         footer = footer,
         footer_pos = "center",


### PR DESCRIPTION
Hello! Maybe this is preference, but I implemented 2 improvements (on my liking, and maybe yours):

1. Hints on bottom of manager window have proper spacing on left and right. Meanwhile title does not has this spacing, which is inconvenient 
2. Plugin does not respects `vim.o.winborder` settings and makes window rounded by default. In my opinion all plugins should respect that option when possible

Let me now it those two changes are lgtm, please