### PR TITLE
fix(yuck): improper use of supertypes in queries

### DIFF
--- a/runtime/queries/yuck/indents.scm
+++ b/runtime/queries/yuck/indents.scm
@@ -1,7 +1,5 @@
 [
   (ast_block)
-  (array)
-  (expr)
   (json_array)
   (json_object)
   (parenthesized_expression)

--- a/runtime/queries/yuck/locals.scm
+++ b/runtime/queries/yuck/locals.scm
@@ -1,8 +1,5 @@
 [
   (ast_block)
-  (list)
-  (array)
-  (expr)
   (json_array)
   (json_object)
   (parenthesized_expression)
@@ -16,6 +13,4 @@
   (simplexpr
     (ident) @local.definition.field))
 
-(ast_block
-  (symbol)
-  (ident) @local.definition.type)
+(symbol) @local.definition.type


### PR DESCRIPTION
Port of https://github.com/nvim-treesitter/nvim-treesitter/pull/8633, one of the last PRs to be merged before archival.

Problem: `(ast_block)` is a supertype, of which `(symbol)` (among others) is a subtype, which makes the final local pattern invalid. (This was not noticed before because the parser is stuck at ABI 14 due to a missing `tree-sitter.json`.)

Solution: Fix the pattern and use supertype where appropriate.