### PR TITLE
feat: jjdescription queries

### DIFF
--- a/runtime/queries/jjdescription/highlights.scm
+++ b/runtime/queries/jjdescription/highlights.scm
@@ -1,0 +1,42 @@
+[
+  (comment)
+  (generated_comment)
+] @comment
+
+(comment_content) @spell
+
+(subject) @markup.heading
+
+(type) @keyword
+
+(scope) @variable.parameter
+
+(change_id) @constant
+
+(filepath) @string.special.path
+
+((rest) @comment
+  (#not-lua-match? @comment "^diff"))
+
+"JJ: ignore-rest" @keyword.directive
+
+[
+  "("
+  ")"
+] @punctuation.bracket
+
+":" @punctuation.delimiter
+
+"!" @punctuation.special
+
+[
+  "A"
+  "C"
+] @diff.plus
+
+"D" @diff.minus
+
+[
+  "M"
+  "R"
+] @diff.delta

--- a/runtime/queries/jjdescription/injections.scm
+++ b/runtime/queries/jjdescription/injections.scm
@@ -1,0 +1,6 @@
+((comment_content) @injection.content
+  (#set! injection.language "comment"))
+
+((rest) @injection.content
+  (#lua-match? @injection.content "^diff")
+  (#set! injection.language "diff"))


### PR DESCRIPTION
We already had the parser but not the queries, this ports them from https://github.com/nvim-treesitter/nvim-treesitter/pull/8625, one of the last PRs to be merged before archival.

Thanks @ribru17!