### PR TITLE
fix(nix): restrict bash injections to direct phase bindings

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -39,7 +39,9 @@
 
 (binding
   attrpath: (attrpath
-    (identifier) @_path)
+    .
+    (identifier) @_path
+    .)
   expression: [
     (string_expression
       ((string_fragment) @injection.content
@@ -53,7 +55,9 @@
 
 (binding
   attrpath: (attrpath
-    (identifier) @_path)
+    .
+    (identifier) @_path
+    .)
   expression: [
     (string_expression
       ((string_fragment) @injection.content
@@ -67,7 +71,9 @@
 
 (binding
   attrpath: (attrpath
-    (identifier) @_path)
+    .
+    (identifier) @_path
+    .)
   expression: [
     (string_expression
       ((string_fragment) @injection.content


### PR DESCRIPTION
Only apply bash injections for phase-like Nix bindings when the attrpath is a single direct identifier.

This avoids false-positive shell injection on dotted attrpaths like `postInstall.labelNamespace.image.repository = "..."` while preserving injection for real phase strings such as `postInstall = '' ... '';`.