### PR TITLE
cannot open output file \\?\D:\ error when compiling parsers with gcc on Windows

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -26,7 +26,9 @@ local function treesitter_build(lang, query_dir, build_path, generate, tmpdir, s
         if out.ok then
             vim.notify("🔨 Building " .. lang)
         end
-        util.run_async({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_path, out, function(out)
+        util.run_async({ "tree-sitter", "build" }, build_path, out, function(out)
+            local dll_file = vim.fn.glob(build_path .."/*" .. util.ext(), false, false)
+            vim.uv.fs_copyfile(dll_file,util.ppath(lang) )
             if out.ok then
                 out = copy_queries(lang, query_dir and vim.fs.joinpath(build_path, query_dir))
             end


### PR DESCRIPTION
fix(treesitter): resolve ld.exe failure on Windows due to \\?\ UNC path prefix

gcc/ld.exe on Windows cannot reliably open output files when the path
is passed with the \\?\ long-path prefix (e.g. \\?\D:\...), causing:

  ld.exe: cannot open output file \\?\D:\... : No such file or directory

Strip the \\?\ prefix before passing the output path to gcc/ld, and
ensure the MinGW/MSYS2 toolchain is used consistently for parser
compilation instead of mixing it with MSVC's link.exe.

This fixes parser builds (e.g. via nvim-treesitter :TSInstall) on
Windows when the data/install directory path exceeds normal length
or triggers Windows' automatic long-path normalization.