### PR TITLE
cannot open output file \\?\D:\ error when compiling parsers with gcc on Windows

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -26,8 +26,12 @@ local function treesitter_build(lang, query_dir, build_path, generate, tmpdir, s
         if out.ok then
             vim.notify("🔨 Building " .. lang)
         end
-        util.run_async({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_path, out, function(out)
+        util.run_async({ "tree-sitter", "build" }, build_path, out, function(out)
             if out.ok then
+                local out_list = vim.fn.glob(build_path .."/*" .. util.ext(), false, true)
+                if out_list ~=nil and out_list[1] ~=nil then
+                    vim.uv.fs_copyfile(out_list[1],util.ppath(lang))
+                end
                 out = copy_queries(lang, query_dir and vim.fs.joinpath(build_path, query_dir))
             end
             vim.fs.rm(tmpdir, { recursive = true, force = true })


### PR DESCRIPTION
```
use gcc ,Parser compilation failed.
   Info  15:02:47 notify.info 🔨 Building zsh
15:03:01 msg_showcmd <20>
   Warn  15:03:03 notify.warn ⚠ Error installing zsh
tree-sitter build -o D:/ab9986/home/nvim-data/site/parser/zsh.dll
[31mError:[0m Failed to compile parser

Caused by:
    Parser compilation failed.
    Stdout: 
    Stderr: In file included from C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c:1:
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c: In function 'exit_context':
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\tree_sitter/array.h:121:42: warning: value computed is not used [-Wunused-value]
      121 | #define array_pop(self) ((self)->contents[--(self)->size])
          |                         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c:252:13: note: in expansion of macro 'array_pop'
      252 |             array_pop(&scanner->context_stack);
          |             ^~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\tree_sitter/array.h:121:42: warning: value computed is not used [-Wunused-value]
      121 | #define array_pop(self) ((self)->contents[--(self)->size])
          |                         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c:260:13: note: in expansion of macro 'array_pop'
      260 |             array_pop(&scanner->context_stack);
          |             ^~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c: In function 'scan_heredoc_content':
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\tree_sitter/array.h:121:42: warning: value computed is not used [-Wunused-value]
      121 | #define array_pop(self) ((self)->contents[--(self)->size])
          |                         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c:642:21: note: in expansion of macro 'array_pop'
      642 |                     array_pop(&scanner->heredocs);
          |                     ^~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c: In function 'scan':
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\tree_sitter/array.h:121:42: warning: value computed is not used [-Wunused-value]
      121 | #define array_pop(self) ((self)->contents[--(self)->size])
          |                         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c:1501:13: note: in expansion of macro 'array_pop'
     1501 |             array_pop(&scanner->heredocs);
          |             ^~~~~~~~~
    C:\Users\ZHANGL~1\AppData\Local\Temp\nvim.0\EqLcAQ\1\src\scanner.c:1606:14: warning: unused variable 'in_param_expand' [-Wunused-variable]
     1606 |         bool in_param_expand = in_parameter_expansion_context(scanner);
          |              ^~~~~~~~~~~~~~~
    D:/ab9986/collect/core/w64devkit/bin/ld.exe: cannot open output file \\?\D:\ab9986\home\nvim-data\site\parser\zsh.dll: Invalid argument
    collect2.exe: error: ld returned 1 exit status
    
```