### PR TITLE
Don't backport install_info if not provided

### DIFF
--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -22,7 +22,10 @@ function M.setup(opts)
     -- User entries take precedence, allowing custom forks and new languages.
     state.effective_repos = vim.deepcopy(state.base_repos)
     for lang, info in pairs(state.cfg.languages) do
-        info.install_info = M.backport_use_repo_queries(info.install_info)
+        if info.install_info then
+            info.install_info = M.backport_use_repo_queries(info.install_info)
+        end
+
         state.effective_repos[lang] = vim.tbl_extend("force", state.effective_repos[lang] or {}, info)
     end
     state.languages = vim.tbl_keys(state.effective_repos)


### PR DESCRIPTION
I'm getting this error on startup after upgrading to 1.0.0

```
Failed to run `config` for tree-sitter-manager.nvim                              
                                    

...sitter-manager.nvim/lua/tree-sitter-manager/backport.lua:5: attempt to index l
ocal 'info' (a nil value)                                                        
                                                                                 
# stacktrace:                                                                    
  - /tree-sitter-manager.nvim/lua/tree-sitter-manager/backport.lua:5 _in_ **backp
ort_use_repo_queries**                                                           
  - /tree-sitter-manager.nvim/lua/tree-sitter-manager/init.lua:27 _in_ **setup** 
  - ~/.config/nvim/lua/plugins/tree-sitter-manager.nvim.lua:8 _in_ **config** 
```

Here's a minimal config that reproduces the issue

```lua
vim.pack.add({
  { src = "https://github.com/romus204/tree-sitter-manager.nvim" },
})

require("tree-sitter-manager").setup({
  languages = {
    elixir = {},
  },
})
```

I think the cleanest fix is to just not attempt the backport if no `install_info` is provided.