### PR TITLE
refactor(util): add helpers for `vim.iter` one-liners

### DIFF
--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -95,11 +95,7 @@ function M.setup(opts)
         nargs = "+",
         bar = true,
         complete = function(_argLead, _cmdLine, _cursorPos)
-            return iter_startswith(_argLead)
-                :filter(function(lang)
-                    return not util.is_installed(lang)
-                end)
-                :totable()
+            return iter_startswith(_argLead, _cmdLine):filter(util.no(util.is_installed)):totable()
         end,
         desc = "Install treesitter parsers",
     })

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -16,11 +16,11 @@ local icon_col
 local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [f] Filter  [q] Close "
 
 local filter_type = {
-    --ok    warn  miss  installing
-    { true, true, true, true }, --    all
-    { true, true, false, true }, --   installed
-    { false, true, false, true }, --  warning
-    { false, false, true, false }, -- missing
+    --            ok    warn  miss  installing
+    util.get({ true, true, true, true }), --    all
+    util.get({ true, true, false, true }), --   installed
+    util.get({ false, true, false, true }), --  warning
+    util.get({ false, false, true, false }), -- missing
 }
 local filter_idx
 
@@ -33,7 +33,7 @@ local M = {}
 
 function M.setup()
     title = config.cfg.nerdfont and title_nerd or title_asci
-    status_icon = config.cfg.nerdfont and status_nerd or status_asci
+    status_icon = util.get(config.cfg.nerdfont and status_nerd or status_asci)
     local langwidth = vim.iter(config.languages):map(string.len):fold(0, math.max)
     formatter = "   %-" .. langwidth .. "s  %s%s"
     icon_col = 3 + langwidth + 2
@@ -53,13 +53,6 @@ local function get_status(lang)
     end
 end
 
-local function get_status_icon_iter(langs)
-    local function get_icon(status)
-        return status_icon[status]
-    end
-    return vim.iter(langs):map(get_status):map(get_icon)
-end
-
 local function get_meta_suffix(lang)
     local info = util.get_repo_info(lang)
     local parts = {}
@@ -75,10 +68,7 @@ local function get_meta_suffix(lang)
 end
 
 local function get_langs_filtered()
-    local function filter(lang)
-        return filter_type[filter_idx][get_status(lang)]
-    end
-    return vim.iter(config.languages):filter(filter):totable()
+    return vim.iter(config.languages):filter(util.compose(filter_type[filter_idx], get_status)):totable()
 end
 
 local function cycle_filter()
@@ -128,7 +118,7 @@ function M.render(out)
         table.sort(vim.list.unique(vim.list_extend(langs, get_langs_filtered())))
     end
 
-    local status = get_status_icon_iter(langs)
+    local status = vim.iter(langs):map(get_status):map(status_icon)
     local meta = vim.iter(langs):map(get_meta_suffix)
     local lines = vim.iter(langs)
         :map(function(lang)

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -7,20 +7,65 @@ local M = {}
 
 M.PLUGIN_ROOT = abs ~= "" and vim.fn.fnamemodify(abs, ":h:h:h") or vim.fn.stdpath("config")
 
+---@vararg table lists to be concatenated (out-of-place)
+---@return table concatenated list
+function M.concat(...)
+    return vim.iter({ ... }):flatten():totable()
+end
+
+---Compose functions
+---@vararg fun
+---@return fun
+function M.compose(f, ...)
+    local g = ... and M.compose(...)
+    return not g and f or function(...)
+        return f(g(...))
+    end
+end
+
+---Logical not of the function output
+---@param f fun
+---@return fun
+function M.no(f)
+    return function(...)
+        return not f(...)
+    end
+end
+
+---@return fun getter function
+function M.get(tbl)
+    return function(key)
+        return tbl[key]
+    end
+end
+
+---@return fun checks inclusion
+function M.isin(list)
+    return function(val)
+        return vim.list_contains(list, val)
+    end
+end
+
+M.notin = M.compose(M.no, M.isin)
+
+---@return string parser extension
 function M.ext()
     local sys = vim.uv.os_uname().sysname
     return sys:match("Windows") and ".dll" or sys:match("Darwin") and ".dylib" or ".so"
 end
 
+---@return string parser path
 function M.ppath(lang)
     return vim.fs.joinpath(config.cfg.parser_dir, lang .. M.ext())
 end
 
+---@return string query path
 function M.qpath(lang)
     return vim.fs.joinpath(config.cfg.query_dir, lang)
 end
 
---- Flat dependency tree.
+---Flat dependency tree.
+---@return string[]
 function M.get_requires(lang)
     local entry = config.effective_repos[lang]
     local deps = entry and entry.requires or {}
@@ -34,6 +79,7 @@ function M.get_requires(lang)
     return deps
 end
 
+---@return table
 function M.get_repo_info(lang)
     local entry = config.effective_repos[lang]
     if not entry then
@@ -55,11 +101,13 @@ function M.get_repo_info(lang)
     return nil
 end
 
+---@return bool
 function M.is_only_query(lang)
     local info = M.get_repo_info(lang)
     return not info or not info.url
 end
 
+---@return bool
 function M.is_installed(lang)
     if vim.list_contains(config.cfg.assume_installed, lang) then
         return true
@@ -68,12 +116,6 @@ function M.is_installed(lang)
     else
         return nil ~= vim.uv.fs_stat(M.ppath(lang))
     end
-end
-
----@vararg table lists to be concatenated (out-of-place)
----@return table concatenated list
-function M.concat(...)
-    return vim.iter({ ... }):flatten():totable()
 end
 
 ---@class Status


### PR DESCRIPTION
- `util.compose(f, g, h)` returns `f(g(h(...)))`
- `util.no(f)` returns `function(...) return not f(...) end`
- `util.get(tbl)` returns `function(k) return tbl[k] end`
- `util.isin(lst)` returns `function(v) return vim.list_contains(lst, v) end`
- `util.notin(lst)` same as `util.isin` but "not in"