### PR TITLE
Validate languages field instead of crashing

### DIFF
--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -27,7 +27,7 @@ function M.setup(opts)
             info.install_info = M.backport_use_repo_queries(info.install_info)
             state.effective_repos[lang] = vim.tbl_extend("force", state.effective_repos[lang] or {}, info)
         else
-            notify.notify(
+            notify(
                 "Language is missing `install_info`, ignoring entry: " .. lang,
                 { icon = "warning", level = vim.log.levels.WARN }
             )

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -1,6 +1,7 @@
 local state = require("tree-sitter-manager.config")
 local util = require("tree-sitter-manager.util")
 local installer = require("tree-sitter-manager.installer")
+local notify = require("tree-sitter-manager.notify")
 local ui = require("tree-sitter-manager.ui")
 
 -- Preserve public API surface for backward compatibility
@@ -22,13 +23,19 @@ function M.setup(opts)
     -- User entries take precedence, allowing custom forks and new languages.
     state.effective_repos = vim.deepcopy(state.base_repos)
     for lang, info in pairs(state.cfg.languages) do
-        info.install_info = M.backport_use_repo_queries(info.install_info)
-        state.effective_repos[lang] = vim.tbl_extend("force", state.effective_repos[lang] or {}, info)
+        if info.install_info then
+            info.install_info = M.backport_use_repo_queries(info.install_info)
+            state.effective_repos[lang] = vim.tbl_extend("force", state.effective_repos[lang] or {}, info)
+        else
+            notify.notify(
+                "Language is missing `install_info`, ignoring entry: " .. lang,
+                { icon = "warning", level = vim.log.levels.WARN }
+            )
+        end
     end
     state.languages = vim.tbl_keys(state.effective_repos)
     table.sort(state.languages)
 
-    installer.setup()
     ui.setup()
 
     vim.fn.mkdir(state.cfg.parser_dir, "p")

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -1,9 +1,7 @@
 local config = require("tree-sitter-manager.config")
 local util = require("tree-sitter-manager.util")
 local backport = require("tree-sitter-manager.backport")
-
-local notify_nerd = { "✕ ", "📦 ", "󰚰 ", "⚠ ", "✓ ", "⚙️ ", "🔨 " }
-local notify_icon
+local notify = require("tree-sitter-manager.notify")
 
 ---@class Installer
 ---@field installing table<Lang, boolean>
@@ -14,10 +12,6 @@ local notify_icon
 ---
 ---@alias Lang string
 local M = { installing = {}, status = {} }
-
-function M.setup()
-    notify_icon = config.cfg.nerdfont and notify_nerd or vim.fn["repeat"]({ "" }, 7)
-end
 
 local function copy_queries(lang, source)
     local qpath = util.qpath(lang)
@@ -36,12 +30,12 @@ end
 local function treesitter_build(lang, query_dir, build_path, generate, tmpdir, status, callback)
     _status = { ok = status.ok and generate, error = status.error }
     if _status.ok then
-        vim.notify(notify_icon[6] .. "Generating " .. lang)
+        notify.notify("Generating " .. lang, { icon = "generate" })
     end
     util.run_async({ "tree-sitter", "generate" }, build_path, _status, function(out)
         out = generate and out or status
         if out.ok then
-            vim.notify(notify_icon[7] .. "Building " .. lang)
+            notify.notify("Building " .. lang, { icon = "build" })
         end
         util.run_async({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_path, out, function(out)
             if out.ok then
@@ -115,7 +109,7 @@ function M.remove(languages, callback, update)
     end
 
     if not update and #uninstalled > 0 then
-        vim.notify(notify_icon[1] .. "Removed " .. table.concat(languages, " "))
+        notify.notify("Removed " .. table.concat(languages, " "), { icon = "removed" })
         callback({ ok = true })
     end
 end
@@ -135,7 +129,7 @@ function M.install(languages, callback, update)
     for _, lang in ipairs(languages) do
         if not config.effective_repos[lang] then
             M.status[lang] = { ok = false, error = "Parser not found in repos" }
-            vim.notify(notify_icon[4] .. "Parser not found in repos: " .. lang, vim.log.levels.WARN)
+            notify.notify("Parser not found in repos: " .. lang, { icon = "warning", level = vim.log.levels.WARN })
         elseif util.is_installed(lang) then
             M.status[lang] = { ok = true }
         elseif not M.installing[lang] then
@@ -143,9 +137,9 @@ function M.install(languages, callback, update)
                 M.status[lang] = out
                 M.installing[lang] = nil
                 if not out.ok then
-                    vim.notify(notify_icon[4] .. "Error installing " .. lang .. "\n" .. out.error, vim.log.levels.WARN)
+                    notify.notify("Error installing " .. lang .. "\n" .. out.error, { icon = "warning", level = vim.log.levels.WARN })
                 else
-                    vim.notify(notify_icon[5] .. (update and "Updated " or "Installed ") .. lang)
+                    notify.notify((update and "Updated " or "Installed ") .. lang, { icon = "success" })
                     -- refresh queries and update highlighting
                     vim.treesitter.query.get:clear()
                     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
@@ -163,9 +157,9 @@ function M.install(languages, callback, update)
 
     if #installing > 0 then
         if update then
-            vim.notify(notify_icon[3] .. "Updating " .. table.concat(installing, " "))
+            notify.notify("Updating " .. table.concat(installing, " "), { icon = "update" })
         else
-            vim.notify(notify_icon[2] .. "Installing " .. table.concat(installing, " "))
+            notify.notify("Installing " .. table.concat(installing, " "), { icon = "install" })
         end
     end
 end

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -137,7 +137,10 @@ function M.install(languages, callback, update)
                 M.status[lang] = out
                 M.installing[lang] = nil
                 if not out.ok then
-                    notify.notify("Error installing " .. lang .. "\n" .. out.error, { icon = "warning", level = vim.log.levels.WARN })
+                    notify.notify(
+                        "Error installing " .. lang .. "\n" .. out.error,
+                        { icon = "warning", level = vim.log.levels.WARN }
+                    )
                 else
                     notify.notify((update and "Updated " or "Installed ") .. lang, { icon = "success" })
                     -- refresh queries and update highlighting

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -30,12 +30,12 @@ end
 local function treesitter_build(lang, query_dir, build_path, generate, tmpdir, status, callback)
     _status = { ok = status.ok and generate, error = status.error }
     if _status.ok then
-        notify.notify("Generating " .. lang, { icon = "generate" })
+        notify("Generating " .. lang, { icon = "generate" })
     end
     util.run_async({ "tree-sitter", "generate" }, build_path, _status, function(out)
         out = generate and out or status
         if out.ok then
-            notify.notify("Building " .. lang, { icon = "build" })
+            notify("Building " .. lang, { icon = "build" })
         end
         util.run_async({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_path, out, function(out)
             if out.ok then
@@ -109,7 +109,7 @@ function M.remove(languages, callback, update)
     end
 
     if not update and #uninstalled > 0 then
-        notify.notify("Removed " .. table.concat(languages, " "), { icon = "removed" })
+        notify("Removed " .. table.concat(languages, " "), { icon = "removed" })
         callback({ ok = true })
     end
 end
@@ -129,7 +129,7 @@ function M.install(languages, callback, update)
     for _, lang in ipairs(languages) do
         if not config.effective_repos[lang] then
             M.status[lang] = { ok = false, error = "Parser not found in repos" }
-            notify.notify("Parser not found in repos: " .. lang, { icon = "warning", level = vim.log.levels.WARN })
+            notify("Parser not found in repos: " .. lang, { icon = "warning", level = vim.log.levels.WARN })
         elseif util.is_installed(lang) then
             M.status[lang] = { ok = true }
         elseif not M.installing[lang] then
@@ -137,12 +137,12 @@ function M.install(languages, callback, update)
                 M.status[lang] = out
                 M.installing[lang] = nil
                 if not out.ok then
-                    notify.notify(
+                    notify(
                         "Error installing " .. lang .. "\n" .. out.error,
                         { icon = "warning", level = vim.log.levels.WARN }
                     )
                 else
-                    notify.notify((update and "Updated " or "Installed ") .. lang, { icon = "success" })
+                    notify((update and "Updated " or "Installed ") .. lang, { icon = "success" })
                     -- refresh queries and update highlighting
                     vim.treesitter.query.get:clear()
                     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
@@ -160,9 +160,9 @@ function M.install(languages, callback, update)
 
     if #installing > 0 then
         if update then
-            notify.notify("Updating " .. table.concat(installing, " "), { icon = "update" })
+            notify("Updating " .. table.concat(installing, " "), { icon = "update" })
         else
-            notify.notify("Installing " .. table.concat(installing, " "), { icon = "install" })
+            notify("Installing " .. table.concat(installing, " "), { icon = "install" })
         end
     end
 end

--- a/lua/tree-sitter-manager/notify.lua
+++ b/lua/tree-sitter-manager/notify.lua
@@ -1,0 +1,41 @@
+local config = require("tree-sitter-manager.config")
+
+---@alias NotifyIcon
+---| "removed"  # Something was removed.
+---| "install"  # An install is in progress.
+---| "update"   # An update is in progress.
+---| "warning"  # Something went wrong.
+---| "success"  # An operation finished successfully.
+---| "generate" # A generation step is in progress.
+---| "build"    # A build step is in progress.
+
+---@type table<NotifyIcon, string>
+local icons = {
+    removed = "✕ ",
+    install = "📦 ",
+    update = "󰚰 ",
+    warning = "⚠ ",
+    success = "✓ ",
+    generate = "⚙️ ",
+    build = "🔨 ",
+}
+
+local M = {}
+
+---@class NotifyOpts
+---@field icon?  NotifyIcon Prefix the message with this icon (nerdfont only).
+---@field level? integer    Log level forwarded to |vim.notify()| (e.g. `vim.log.levels.WARN`).
+
+---Display a notification, optionally prefixed with an icon.
+---@param message string      The notification message.
+---@param opts?   NotifyOpts  Optional settings selecting an icon and log level.
+function M.notify(message, opts)
+    opts = opts or {}
+    local prefix = ""
+    if opts.icon and config.cfg.nerdfont then
+        prefix = icons[opts.icon] or ""
+    end
+    vim.notify(prefix .. message, opts.level)
+end
+
+return M

--- a/lua/tree-sitter-manager/notify.lua
+++ b/lua/tree-sitter-manager/notify.lua
@@ -20,8 +20,6 @@ local icons = {
     build = "🔨 ",
 }
 
-local M = {}
-
 ---@class NotifyOpts
 ---@field icon?  NotifyIcon Prefix the message with this icon (nerdfont only).
 ---@field level? integer    Log level forwarded to |vim.notify()| (e.g. `vim.log.levels.WARN`).
@@ -29,7 +27,7 @@ local M = {}
 ---Display a notification, optionally prefixed with an icon.
 ---@param message string      The notification message.
 ---@param opts?   NotifyOpts  Optional settings selecting an icon and log level.
-function M.notify(message, opts)
+return function(message, opts)
     opts = opts or {}
     local prefix = ""
     if opts.icon and config.cfg.nerdfont then
@@ -37,5 +35,3 @@ function M.notify(message, opts)
     end
     vim.notify(prefix .. message, opts.level)
 end
-
-return M


### PR DESCRIPTION
<img width="517" height="308" alt="image" src="https://github.com/user-attachments/assets/ea169697-c442-4bb1-88bb-d2717716bad6" />

Follow-up to https://github.com/romus204/tree-sitter-manager.nvim/pull/163, this notifies the user if their configuration is incorrect, and skips reconfiguring the language. 