### PR TITLE
feat: add crystal grammar (crystal-lang-tools/tree-sitter-crystal)

### DIFF
--- a/lua/tree-sitter-manager/repos.lua
+++ b/lua/tree-sitter-manager/repos.lua
@@ -215,6 +215,13 @@ return {
         },
         requires = { "c" },
     },
+    crystal = {
+        install_info = {
+            queries = "queries/nvim",
+            revision = "50ca9e6fcfb16a2cbcad59203cfd8ad650e25c49",
+            url = "https://github.com/crystal-lang-tools/tree-sitter-crystal",
+        },
+    },
     css = {
         install_info = {
             revision = "dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f",


### PR DESCRIPTION
## Summary

Add native support for the [Crystal](https://crystal-lang.org) language, using the official parser maintained by the Crystal tooling team: [crystal-lang-tools/tree-sitter-crystal](https://github.com/crystal-lang-tools/tree-sitter-crystal).

## Details

- The revision is pinned to the current upstream HEAD (`50ca9e6`).
- The entry uses `queries = "queries/nvim"`: the upstream repository maintains Neovim-specific queries (`highlights.scm`, `folds.scm`, `injections.scm`) following nvim capture conventions, so they are copied directly from the parser repo and stay in sync with the pinned revision — no files to bundle in `runtime/queries/`. This is the first built-in entry using this option, which is already documented in the README and covered by `test_treesitter` (the `{ "queries", "razor" }` case).
- No `filetypes.lua` entry needed: Neovim natively detects `*.cr` as `crystal` (verified with `vim.filetype.match`).
- Crystal was never part of nvim-treesitter, so there were no queries to source from the archived repo.

## Testing

- `make test_highlight crystal`: 4/4 passing — full real install (clone, build via tree-sitter CLI, query copy) and working highlighting.
- Note: `make test crystal` shows a failure in `test_ui.lua | filter | missing`, but it is unrelated to this change — it reproduces identically with pre-existing languages (e.g. `make test_ui json`) when the UI test runs with a single dependency-free language. `make test_ui` with its default language set passes 8/8.
