### PR TITLE
perf(util): queue up all async calls, remove batching in installer

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -74,8 +74,8 @@ T["test-case"] = function(lang)
 
     -- Parameters:
     -- languages to be installed
-    -- timeout (default 60s)
-    -- return_error, whether to return the error message or throw it
+    -- timeout (default 60,000 ms)
+    -- return_error (default false), whether to return the error message or throw it
     child.install(languages, 60000, false)
 
     child.works(lang, "parser") -- checks parser

--- a/doc/tree-sitter-manager.txt
+++ b/doc/tree-sitter-manager.txt
@@ -57,10 +57,11 @@ lazy.nvim: >lua
   }
 <
 
-vim-plug: >vim
-  Plug 'romus204/tree-sitter-manager.nvim'
-<
-  Then in your `init.lua`: >lua
+vim.pack: >lua
+  vim.pack.add({
+    { src = "https://github.com/romus204/tree-sitter-manager.nvim" }
+  })
+
   require("tree-sitter-manager").setup({})
 <
 
@@ -84,6 +85,8 @@ vim-plug: >vim
     border           = "rounded",
     min_width        = 78,
     min_height       = 40,
+    -- tree-sitter-manager.util
+    async_size       = 64,
   })
 <
 

--- a/lua/tree-sitter-manager/config.lua
+++ b/lua/tree-sitter-manager/config.lua
@@ -3,10 +3,10 @@ local repos = require("tree-sitter-manager.repos")
 local M = {}
 local datapath = vim.fn.stdpath("data")
 
----@class tree-sitter-manager.Config
+---@class tree_sitter_manager.Config
 ---@field parser_dir? string Directory to install compiled parsers into. Defaults to `stdpath('data')/site/parser`.
 ---@field query_dir? string Directory to install query files into. Defaults to `stdpath('data')/site/queries`.
----@field languages? table<string, string|tree-sitter-manager.LanguageSpec> User-defined language repos to use instead of the built-in ones. Can either be a string (a git URL), or a more detailed LanguageSpec.
+---@field languages? table<string, string|tree_sitter_manager.LanguageSpec> User-defined language repos to use instead of the built-in ones. Can either be a string (a git URL), or a more detailed LanguageSpec.
 ---@field assume_installed? string[] Languages to never install.
 ---@field ensure_installed? string|string[] Languages to install on `setup()` if not already present. Use `"all"` to install all languages.
 ---@field auto_install? boolean Install missing parsers automatically on `FileType`.
@@ -17,19 +17,20 @@ local datapath = vim.fn.stdpath("data")
 ---@field border? string|string[] Border style passed to `nvim_open_win` for the manager UI.
 ---@field min_width? number Minimum width of the TUI window.
 ---@field min_height? number Minimum height of the TUI window.
+---@field async_size? number Maximum number of async jobs.
 
----@class tree-sitter-manager.LanguageSpec
----@field install_info? tree-sitter-manager.InstallInfo Information about how to fetch and build the grammar.
+---@class tree_sitter_manager.LanguageSpec
+---@field install_info? tree_sitter_manager.InstallInfo Information about how to fetch and build the grammar.
 ---@field requires? string[] Other languages that are dependencies of this one and must be installed first.
 
----@class tree-sitter-manager.InstallInfo
+---@class tree_sitter_manager.InstallInfo
 ---@field url string Git URL of the grammar repository.
 ---@field location? string Sub-directory within the repo where the grammar is stored. Defaults to the name of the language.
 ---@field revision? string Git revision to check out after cloning. Takes priority over `branch`.
 ---@field branch? string Git branch to check out after cloning. Ignored if `revision` is set.
 ---@field generate? boolean Run `tree-sitter generate` before building. Defaults to false.
 ---@field queries? string Specifies the queries directory in the cloned repo that will be used.
----@type tree-sitter-manager.Config
+---@type tree_sitter_manager.Config
 M.cfg = {
     parser_dir = vim.fs.joinpath(datapath, "site/parser"),
     query_dir = vim.fs.joinpath(datapath, "site/queries"),
@@ -44,6 +45,7 @@ M.cfg = {
     border = "rounded",
     min_width = 78,
     min_height = 40,
+    async_size = 64,
 }
 
 M.base_repos = repos

--- a/lua/tree-sitter-manager/health.lua
+++ b/lua/tree-sitter-manager/health.lua
@@ -1,3 +1,5 @@
+local util = require("tree-sitter-manager.util")
+
 local M = {}
 
 M.check = function()
@@ -16,8 +18,8 @@ M.check = function()
         if vim.fn.executable(command_name) == 0 then
             vim.health.error(human_readable_name .. " must be installed")
         else
-            local version = vim.system({ command_name, "--version" }):wait()
-            local first_line = vim.fn.split(version.stdout, "\n")[1]
+            local version = util.run({ cmd, "--version" }):wait()
+            local first_line = vim.split(version.stdout, "\n")[1]
             vim.health.ok(human_readable_name .. " is installed: " .. first_line)
         end
     end

--- a/lua/tree-sitter-manager/init.lua
+++ b/lua/tree-sitter-manager/init.lua
@@ -9,8 +9,8 @@ local M = require("tree-sitter-manager.backport")
 local function iter_startswith(_argLead, _cmdLine)
     local args = vim.split(_cmdLine, " +")
     table.remove(args) -- don't include last word
-    return vim.iter(state.languages):filter(function(lang)
-        return vim.startswith(lang, _argLead) and not vim.list_contains(args, lang)
+    return vim.iter(state.languages):filter(util.notin(args)):filter(function(lang)
+        return vim.startswith(lang, _argLead)
     end)
 end
 

--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -33,7 +33,7 @@ local function copy_queries(lang, source)
     end
 end
 
-local function treesitter_build(lang, info, tmpdir, status, callback)
+local function build(lang, info, tmpdir, status, callback)
     local build_path = vim.fs.joinpath(tmpdir, info.location)
     if status.ok and not vim.uv.fs_stat(build_path) then
         status = { ok = false, error = lang .. ": invalid location: " .. info.location }
@@ -44,34 +44,43 @@ local function treesitter_build(lang, info, tmpdir, status, callback)
         vim.notify(notify_icon[6] .. "Generating " .. lang)
     end
 
-    util.run_async({ "tree-sitter", "generate" }, build_path, _status, function(out)
-        out = info.generate and out or status
-        if out.ok then
-            vim.notify(notify_icon[7] .. "Building " .. lang)
-        end
-        util.run_async({ "tree-sitter", "build", "-o", util.ppath(lang) }, build_path, out, function(out)
+    local queue = util.Queue:new() -- skip global_queue
+    util.run({ "tree-sitter", "generate" }, {
+        cwd = build_path,
+        status = _status,
+        queue = queue,
+        callback = function(out)
+            out = info.generate and out or status
             if out.ok then
-                out = copy_queries(lang, info.queries and vim.fs.joinpath(build_path, info.queries))
+                vim.notify(notify_icon[7] .. "Building " .. lang)
             end
-            vim.fs.rm(tmpdir, { recursive = true, force = true })
-            callback(out)
-        end)
-    end)
+            util.run({ "tree-sitter", "build", "-o", util.ppath(lang) }, {
+                cwd = build_path,
+                status = out,
+                queue = queue,
+                callback = function(out)
+                    if out.ok then
+                        out = copy_queries(lang, info.queries and vim.fs.joinpath(build_path, info.queries))
+                    end
+                    vim.fs.rm(tmpdir, { recursive = true, force = true })
+                    callback(out)
+                end,
+            })
+        end,
+    })
 end
 
-local function install(lang, on_finish)
-    local function callback(out)
-        on_finish(out, lang)
-    end
+local function install(lang, callback)
+    callback = callback or function() end
 
     if util.is_only_query(lang) then
         callback(copy_queries(lang))
         return
     end
 
-    local out = util.run({ "git", "version" })
+    local out = util.run({ "git", "version" }):wait()
     if not out.ok then
-        callback({ ok = false, error = "Git not installed" })
+        callback(out)
         return
     end
     local version = { out.output:match("(%d+)%.(%d+)%.(%d+)") }
@@ -83,27 +92,28 @@ local function install(lang, on_finish)
 
     if info.revision and (major < 2 or major == 2 and minor < 49) then
         -- Git pre 2.49.0 doesn't have --revision flag
-        out = util.run(util.concat(git_args, { "init", tmpdir }))
+        out = util.run(util.concat(git_args, { "init", tmpdir })):wait()
         if out.ok then
-            out = util.run(util.concat(git_args, { "remote", "add", "origin", info.url }))
+            out = util.run(util.concat(git_args, { "remote", "add", "origin", info.url })):wait()
         end
-        util.run_async(util.concat(git_args, { "fetch", "--depth=1", "origin", info.revision }), nil, out, function(out)
-            if out.ok then
-                out = util.run(util.concat(git_args, { "checkout", "FETCH_HEAD" }))
-            end
-            treesitter_build(lang, info, tmpdir, out, callback)
-        end)
+        util.run(util.concat(git_args, { "fetch", "--depth=1", "origin", info.revision }), {
+            status = out,
+            callback = function(out)
+                if out.ok then
+                    out = util.run(util.concat(git_args, { "checkout", "FETCH_HEAD" })):wait()
+                end
+                build(lang, info, tmpdir, out, callback)
+            end,
+        })
     else
         local revision = info.revision and "--revision=" .. info.revision
         local branch = info.branch and "--branch=" .. info.branch
-        util.run_async(
-            util.concat(git_args, { "clone", "--depth=1", info.url, tmpdir, revision or branch }),
-            nil,
-            out,
-            function(out)
-                treesitter_build(lang, info, tmpdir, out, callback)
-            end
-        )
+        util.run(util.concat(git_args, { "clone", "--depth=1", info.url, tmpdir, revision or branch }), {
+            status = out,
+            callback = function(out)
+                build(lang, info, tmpdir, out, callback)
+            end,
+        })
     end
 end
 
@@ -122,30 +132,13 @@ function M.remove(languages, callback, update)
     end
 
     if not update and #uninstalled > 0 then
-        vim.notify(notify_icon[1] .. "Removed " .. table.concat(languages, " "))
+        vim.notify(notify_icon[1] .. "Removed " .. table.concat(uninstalled, " "))
         callback({ ok = true })
     end
 end
 
 function M.install(languages, callback, update)
     languages = type(languages) == "string" and { languages } or languages
-    local function on_finish(out, lang)
-        M.status[lang] = out
-        M.installing[lang] = nil
-        if not out.ok then
-            vim.notify(notify_icon[4] .. "Error installing " .. lang .. "\n" .. out.error, vim.log.levels.WARN)
-        else
-            vim.notify(notify_icon[5] .. (update and "Updated " or "Installed ") .. lang)
-            -- refresh queries and update highlighting
-            vim.treesitter.query.get:clear()
-            for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-                pcall(vim.treesitter.start, buf)
-            end
-        end
-        if callback then
-            callback(out)
-        end
-    end
 
     local lang_n_deps = {}
     for i, lang in ipairs(languages) do
@@ -163,26 +156,31 @@ function M.install(languages, callback, update)
             vim.notify(notify_icon[4] .. lang .. " not in repos", vim.log.levels.WARN)
         elseif util.is_installed(lang) then
             M.status[lang] = { ok = true }
-        elseif util.is_only_query(lang) then
-            install(lang, on_finish)
-        elseif not M.installing[lang] then
-            M.installing[lang] = true
-            table.insert(installing, lang)
-        end
-    end
-
-    local function install_batch(i, size)
-        local batch = vim.list_slice(installing, i, i + size - 1)
-        for _, lang in ipairs(batch) do
-            install(lang, function(out, lang)
-                on_finish(out, lang)
-                if not vim.iter(batch):any(util.get(M.installing)) then
-                    install_batch(i + size, size)
+        elseif M.installing[lang] then
+        else
+            install(lang, function(out)
+                M.status[lang] = out
+                M.installing[lang] = nil
+                if not out.ok then
+                    vim.notify(notify_icon[4] .. "Error installing " .. lang .. "\n" .. out.error, vim.log.levels.WARN)
+                else
+                    vim.notify(notify_icon[5] .. (update and "Updated " or "Installed ") .. lang)
+                    -- refresh queries and update highlighting
+                    vim.treesitter.query.get:clear()
+                    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+                        pcall(vim.treesitter.start, buf)
+                    end
+                end
+                if callback then
+                    callback(out)
                 end
             end)
+            if not util.is_only_query(lang) then
+                M.installing[lang] = true
+                table.insert(installing, lang)
+            end
         end
     end
-    install_batch(1, 64)
 
     if #installing > 0 then
         if update then

--- a/lua/tree-sitter-manager/ui.lua
+++ b/lua/tree-sitter-manager/ui.lua
@@ -10,17 +10,17 @@ local title
 
 local status_asci = { "OK", "!!", "..", "  " }
 local status_nerd = { "✅", "⚠️", "❌", "  " }
-local status_icon
+local get_status_icon
 local icon_col
 
 local footer = " [i] Install  [x] Remove  [u] Update  [r] Refresh  [f] Filter  [q] Close "
 
 local filter_type = {
     --            ok    warn  miss  installing
-    util.get({ true, true, true, true }), --    all
-    util.get({ true, true, false, true }), --   installed
-    util.get({ false, true, false, true }), --  warning
-    util.get({ false, false, true, false }), -- missing
+    util.getter({ true, true, true, true }), --    all
+    util.getter({ true, true, false, true }), --   installed
+    util.getter({ false, true, false, true }), --  warning
+    util.getter({ false, false, true, false }), -- missing
 }
 local filter_idx
 
@@ -33,7 +33,7 @@ local M = {}
 
 function M.setup()
     title = config.cfg.nerdfont and title_nerd or title_asci
-    status_icon = util.get(config.cfg.nerdfont and status_nerd or status_asci)
+    get_status_icon = util.getter(config.cfg.nerdfont and status_nerd or status_asci)
     local langwidth = vim.iter(config.languages):map(string.len):fold(0, math.max)
     formatter = "   %-" .. langwidth .. "s  %s%s"
     icon_col = 3 + langwidth + 2
@@ -68,7 +68,11 @@ local function get_meta_suffix(lang)
 end
 
 local function get_langs_filtered()
-    return vim.iter(config.languages):filter(util.compose(filter_type[filter_idx], get_status)):totable()
+    return vim.iter(config.languages)
+        :filter(function(lang)
+            return filter_type[filter_idx](get_status(lang))
+        end)
+        :totable()
 end
 
 local function cycle_filter()
@@ -97,19 +101,15 @@ local function render_spinner()
     end
 end
 
-local act = setmetatable({}, {
-    __index = function(act, action)
-        local function _action()
-            local lang = vim.api.nvim_get_current_line():match("^%s*([%w_]+)")
-            if lang then
-                installer[action](lang, M.render)
-                M.render(true)
-            end
+local act = vim.defaulttable(function(action)
+    return function()
+        local lang = vim.api.nvim_get_current_line():match("^%s*([%w_]+)")
+        if lang then
+            installer[action](lang, M.render)
+            M.render(true)
         end
-        rawset(act, action, _action)
-        return _action
-    end,
-})
+    end
+end)
 
 function M.render(out)
     if not buf or not vim.api.nvim_buf_is_valid(buf) then
@@ -118,7 +118,7 @@ function M.render(out)
         table.sort(vim.list.unique(vim.list_extend(langs, get_langs_filtered())))
     end
 
-    local status = vim.iter(langs):map(get_status):map(status_icon)
+    local status = vim.iter(langs):map(get_status):map(get_status_icon)
     local meta = vim.iter(langs):map(get_meta_suffix)
     local lines = vim.iter(langs)
         :map(function(lang)

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -7,46 +7,45 @@ local M = {}
 
 M.PLUGIN_ROOT = abs ~= "" and vim.fn.fnamemodify(abs, ":h:h:h") or vim.fn.stdpath("config")
 
----@vararg table lists to be concatenated (out-of-place)
----@return table concatenated list
+---concat({1,2,3}, {4,5}) = {1,2,3,4,5}
+---Does not mutate lists.
+---@vararg any[]
+---@return any[]
 function M.concat(...)
     return vim.iter({ ... }):flatten():totable()
 end
 
----Compose functions
----@vararg fun
----@return fun
-function M.compose(f, ...)
-    local g = ... and M.compose(...)
-    return not g and f or function(...)
-        return f(g(...))
+---get(key)(tbl) = tbl[key]
+---@return function
+function M.get(key)
+    return function(tbl)
+        return tbl[key]
     end
 end
 
----Logical not of the function output
----@param f fun
----@return fun
-function M.no(f)
-    return function(...)
-        return not f(...)
-    end
-end
-
----@return fun getter function
-function M.get(tbl)
+---getter(tbl)(key) = tbl[key]
+---@return function
+function M.getter(tbl)
     return function(key)
         return tbl[key]
     end
 end
 
----@return fun checks inclusion
+---isin({ x, y, z })(x) = true
+---@return function
 function M.isin(list)
     return function(val)
         return vim.list_contains(list, val)
     end
 end
 
-M.notin = M.compose(M.no, M.isin)
+---notin({ x, y, z })(w) = true
+---@return function
+function M.notin(list)
+    return function(val)
+        return not vim.list_contains(list, val)
+    end
+end
 
 ---@return string parser extension
 function M.ext()
@@ -123,33 +122,108 @@ end
 ---@field error? string
 ---@field output? string
 
----@param args string[]
----@param cwd string
----@return Status
-function M.run(args, cwd)
-    local out = vim.system(args, { text = true, cwd = cwd }):wait()
-    local err = table.concat(args, " ") .. "\n" .. (out.stderr or "")
-    return { ok = out.code == 0, error = err, output = out.stdout }
+---@class AsyncJob
+---@field wait fun(self: AsyncJob, timeout: number): Status
+---@field start fun(self: AsyncJob) Start the job immediately.
+---@field active boolean
+
+---@class Queue: AsyncJob[]
+---@field new fun(self): Queue
+---@field find fun(self, job: AsyncJob): number, AsyncJob
+---@field add fun(self, job: AsyncJob)
+---@field remove fun(self, job: AsyncJob)
+---@field start_next_batch fun(self) Start the next batch capped at `async_size`
+local Queue = {}
+Queue.__index = Queue
+
+function Queue:new()
+    return setmetatable({}, self)
 end
 
+---@return number The index of the job
+---@return AsyncJob The job itself
+function Queue:find(job)
+    return vim.iter(ipairs(self)):find(function(_, j)
+        return j == job
+    end)
+end
+
+Queue.add = table.insert
+
+function Queue:remove(job)
+    local i = self:find(job) or 0
+    table.remove(self, i)
+end
+
+function Queue:start_next_batch()
+    local active = #vim.iter(self):filter(M.get("active")):totable()
+    for i = active + 1, math.min(#self, config.cfg.async_size) do
+        self[i]:start()
+    end
+end
+
+M.Queue = Queue
+M.global_queue = Queue:new()
+
+---@class runOptions
+---@field callback? fun(out: Status) If not given the job skips the queue.
+---@field status? Status If not status.ok, the job is skipped to the callback.
+---@field queue? Queue Jobs are queued, by default `global_queue`. Use Queue:new() to skip the queue.
+---@field [string] any Additional options are forwarded to vim.system
+
 ---@param args string[]
----@param cwd string
----@param status Status
----@param callback fun(out:Status)
-function M.run_async(args, cwd, status, callback)
-    callback = callback or function() end
+---@param opts? runOptions
+---@return AsyncJob
+function M.run(args, opts)
+    opts = opts or {}
+    local status = opts.status or { ok = true }
+    local queue = opts.queue or opts.callback and Queue:new() or M.global_queue
+    local callback = opts.callback or function() end
 
     if not status.ok then
         callback(status)
         return
     end
 
-    vim.system(args, { text = true, cwd = cwd }, function(out)
-        vim.schedule(function()
-            local err = table.concat(args, " ") .. "\n" .. (out.stderr or "")
-            callback({ ok = out.code == 0, error = err, output = out.stdout })
+    local job = {} ---@type AsyncJob
+
+    function job:start()
+        self.start = function() end -- subsequent calls do nothing
+
+        opts.text = true
+        local obj = vim.system(args, opts, function(out)
+            vim.schedule(function()
+                queue:remove(self)
+                queue:start_next_batch()
+                local err = table.concat(args, " ") .. "\n" .. (out.stderr or "")
+                callback({ ok = out.code == 0, error = err, output = out.stdout })
+            end)
         end)
-    end)
+
+        function self:wait(...) -- replace job:wait with the actual SystemObj:wait
+            local out = obj:wait(...)
+            local err = table.concat(args, " ") .. "\n" .. (out.stderr or "")
+            return { ok = out.code == 0, error = err, output = out.stdout }
+        end
+
+        self.active = true
+    end
+
+    function job:wait(timeout)
+        timeout = timeout or math.huge
+        local start = vim.uv.hrtime()
+        -- wait until the job starts
+        if vim.wait(timeout, function()
+            return self.active
+        end) then -- wait until the job finishes
+            return self:wait(timeout - (vim.uv.hrtime() - start) / 1e6)
+        end
+    end
+
+    queue:add(job)
+    queue:start_next_batch()
+
+    return job
 end
 
 function M.copy_dir(src, dst)

--- a/scripts/nvim/init.lua
+++ b/scripts/nvim/init.lua
@@ -5,6 +5,8 @@ vim.cmd([[let &rtp.=','.getcwd()]])
 -- Assumed that 'mini.nvim' is stored in 'deps/mini.nvim'
 vim.cmd("set rtp+=deps/mini.nvim")
 
+require("vim._core.ui2").enable()
+
 -- Set up 'tree-sitter-manager'
 vim.cmd.runtime("plugin/filetypes.lua")
 tsm = require("tree-sitter-manager")

--- a/tests/child.lua
+++ b/tests/child.lua
@@ -1,6 +1,6 @@
 local M = MiniTest.new_child_neovim()
 
----@param config tree-sitter-manager.Config
+---@param config tree_sitter_manager.Config
 function M.setup(config)
     M.name = MiniTest.current.case and MiniTest.current.case.desc[1] or "tests/interactive_session"
     local path = vim.fs.joinpath(vim.fn.stdpath("data"), M.name)
@@ -36,15 +36,18 @@ function M.wait(languages, timeout, return_error)
     -- add dependencies
     vim.list.unique(vim.list_extend(languages, vim.iter(languages):map(util.get_requires):flatten():totable()))
     -- don't wait for languages already timed out
-    languages = vim.iter(languages):filter(util.no(util.get(M.timeout))):totable()
+    languages = vim.iter(languages)
+        :filter(function(lang)
+            return not M.timeout[lang]
+        end)
+        :totable()
     timeout = timeout or 60000
     M.lua([[
     success, reason = vim.wait(
         ]] .. timeout .. [[,
         function()
-            return not vim.iter(]] .. vim.inspect(languages) .. [[):any(util.get(installer.installing))
-        end,
-        1000
+            return not vim.iter(]] .. vim.inspect(languages) .. [[):any(util.getter(installer.installing))
+        end
     )
     ]])
 
@@ -52,7 +55,7 @@ function M.wait(languages, timeout, return_error)
     if not M.lua_get("success") then
         local reason = M.lua_get("reason")
         local failed =
-            M.lua_get("vim.iter(" .. vim.inspect(languages) .. "):filter(util.get(installer.installing)):totable()")
+            M.lua_get("vim.iter(" .. vim.inspect(languages) .. "):filter(util.getter(installer.installing)):totable()")
         if reason == -1 then
             for _, lang in ipairs(failed) do
                 M.timeout[lang] = true
@@ -104,9 +107,11 @@ function M.works(languages, query)
             eq(true, M.lua_get("nil ~= vim.treesitter.query.get('" .. lang .. "', '" .. query .. "')"))
         end
     else
-        vim.iter(languages):filter(util.no(util.is_only_query)):each(function(lang)
-            M.lua("vim.treesitter.get_string_parser('', '" .. lang .. "')")
-        end)
+        for _, lang in ipairs(languages) do
+            if not util.is_only_query(lang) then
+                M.lua("vim.treesitter.get_string_parser('', '" .. lang .. "')")
+            end
+        end
     end
 end
 
@@ -121,11 +126,13 @@ function M.fails(languages, query)
             eq(false, M.lua_get("nil ~= vim.treesitter.query.get('" .. lang .. "', '" .. query .. "')"))
         end
     else
-        vim.iter(languages):filter(util.no(util.is_only_query)):each(function(lang)
-            er(function()
-                M.lua("vim.treesitter.get_string_parser('', '" .. lang .. "')")
-            end, "No parser")
-        end)
+        for _, lang in ipairs(languages) do
+            if not util.is_only_query(lang) then
+                er(function()
+                    M.lua("vim.treesitter.get_string_parser('', '" .. lang .. "')")
+                end, "No parser")
+            end
+        end
     end
 end
 

--- a/tests/test_all_queries.lua
+++ b/tests/test_all_queries.lua
@@ -28,7 +28,9 @@ local T = new_set({
 })
 
 T.pass = function(lang, query)
-    if fail_parser[lang] then
+    if util.is_only_query(lang) then
+        MiniTest.skip("query dependency")
+    elseif fail_parser[lang] then
         MiniTest.skip("failed parser")
     end
     fail_parser[lang] = query == "parser"

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -13,9 +13,11 @@ T.TSUpdate = function()
     child.cmd("TSUpdate " .. table.concat(languages, " "))
     eq(
         false,
-        child.lua_get(
-            "vim.iter(" .. vim.inspect(languages) .. [[):filter(util.no(util.is_only_query)):any(util.is_installed)]]
-        )
+        child.lua_get("vim.iter(" .. vim.inspect(languages) .. [[)
+            :filter(function(lang)
+                return not util.is_only_query(lang)
+            end)
+            :any(util.is_installed)]])
     )
     child.wait(languages)
     child.works(languages, "parser")
@@ -26,9 +28,11 @@ T["TSUpdate!"] = function()
     child.cmd("TSUpdate!")
     eq(
         false,
-        child.lua_get(
-            "vim.iter(" .. vim.inspect(languages) .. [[):filter(util.no(util.is_only_query)):any(util.is_installed)]]
-        )
+        child.lua_get("vim.iter(" .. vim.inspect(languages) .. [[)
+            :filter(function(lang)
+                return not util.is_only_query(lang)
+            end)
+            :any(util.is_installed)]])
     )
     child.wait(languages)
     child.works(languages, "parser")

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -41,7 +41,7 @@ T.revision.pre_2_49 = new_set({
                 return system(cmd, ...)
             end
             ]])
-            local version = { child.lua_get('util.run({ "git", "version" }).output'):match("(%d+)%.(%d+)%.(%d+)") }
+            local version = { child.lua_get('util.run({"git","version"}):wait().output'):match("(%d+)%.(%d+)%.(%d+)") }
             local major, minor, patch = unpack(vim.iter(version):map(tonumber):totable())
             eq(true, major < 2 or major == 2 and minor < 49)
         end,

--- a/tests/test_ui.lua
+++ b/tests/test_ui.lua
@@ -17,9 +17,11 @@ T.update = function()
     child.cmd("g/\\v^ *(" .. table.concat(languages, "|") .. ") /normal u")
     eq(
         false,
-        child.lua_get(
-            "vim.iter(" .. vim.inspect(languages) .. "):filter(util.no(util.is_only_query)):any(util.is_installed)"
-        )
+        child.lua_get("vim.iter(" .. vim.inspect(languages) .. [[)
+            :filter(function(lang)
+                return not util.is_only_query(lang)
+            end)
+            :any(util.is_installed)]])
     )
     child.wait(languages)
     child.works(languages, "parser")


### PR DESCRIPTION
Added `async_size` option to control how many languages can be installed simultaneously. 64 as the default should be plenty and won't change user experience.

This PR is needed to optimize CI in the future.