### PR TITLE
test: manage filetypes that shouldn't exist

### DIFF
--- a/lua/tree-sitter-manager/invalid-filetypes.lua
+++ b/lua/tree-sitter-manager/invalid-filetypes.lua
@@ -1,0 +1,3 @@
+return {
+    "glimmer", -- This is not a proper filetype. Use either of {java,type}script.glimmer
+}

--- a/lua/tree-sitter-manager/util.lua
+++ b/lua/tree-sitter-manager/util.lua
@@ -2,6 +2,7 @@ local src = debug.getinfo(1, "S").source
 local abs = src:sub(1, 1) == "@" and vim.fn.fnamemodify(src:sub(2), ":p") or ""
 
 local config = require("tree-sitter-manager.config")
+local invalid = require("tree-sitter-manager.invalid-filetypes")
 
 local M = {}
 
@@ -61,6 +62,12 @@ end
 ---@return string query path
 function M.qpath(lang)
     return vim.fs.joinpath(config.cfg.query_dir, lang)
+end
+
+---Wrapper for vim.treesitter.language.get_filetypes()
+---@return string[] list of filetypes
+function M.get_filetypes(lang)
+    return vim.iter(vim.treesitter.language.get_filetypes(lang)):filter(M.notin(invalid)):totable()
 end
 
 ---Flat dependency tree.

--- a/tests/test_auto_install.lua
+++ b/tests/test_auto_install.lua
@@ -1,7 +1,7 @@
 local languages = _G.languages or { "tsv", "tsx" }
 
 local T = new_set({
-    parametrize = parametrize(vim.iter(languages):map(vim.treesitter.language.get_filetypes):flatten():totable()),
+    parametrize = parametrize(vim.iter(languages):map(util.get_filetypes):flatten():totable()),
 })
 
 T.noauto_install = MiniTest.new_set({

--- a/tests/test_highlight.lua
+++ b/tests/test_highlight.lua
@@ -6,7 +6,7 @@ local T = new_set({
             child.setup({ highlight = true })
         end,
     },
-    parametrize = parametrize(vim.iter(languages):map(vim.treesitter.language.get_filetypes):flatten():totable()),
+    parametrize = parametrize(vim.iter(languages):map(util.get_filetypes):flatten():totable()),
 })
 
 T.before_install = function(ft)


### PR DESCRIPTION
Currently only "glimmer" is invalid. The proper filetype for the language "glimmer" is either "handlebars", "html.handlebars", "javascript.glimmer", or "typescript.glimmer".

This only breaks some tests. The user should never be concerned about this.