### PR TITLE
fix: run legacy Git commands in temporary repository

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -78,11 +78,11 @@ local function install(lang, callback)
         -- Git pre 2.49.0 doesn't have --revision flag
         out = util.run({ "git", "init", tmpdir })
         if out.ok then
-            out = util.run(util.concat(git_args, { "remote", "add", "origin", info.url }))
+            out = util.run(util.concat(git_args, { "remote", "add", "origin", info.url }), tmpdir)
         end
-        util.run_async(util.concat(git_args, { "fetch", "--depth=1", "origin", info.revision }), nil, out, function(out)
+        util.run_async(util.concat(git_args, { "fetch", "--depth=1", "origin", info.revision }), tmpdir, out, function(out)
             if out.ok then
-                out = util.run(util.concat(git_args, { "checkout", "FETCH_HEAD" }))
+                out = util.run(util.concat(git_args, { "checkout", "FETCH_HEAD" }), tmpdir)
             end
             treesitter_build(lang, info.queries, build_path, info.generate, tmpdir, out, callback)
         end)

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -96,6 +96,20 @@ T["pre_2.49.0"] = MiniTest.new_set({
                 end
                 return system(cmd, ...)
             end
+
+            -- Ensure Git cannot discover the plugin's own repository.
+            pre_249_cwd = vim.fn.tempname()
+            vim.fn.mkdir(pre_249_cwd, "p")
+            vim.fn.chdir(pre_249_cwd)
+            ]])
+        end,
+        post_once = function()
+            if not child.is_running() then
+                return
+            end
+            child.lua([[
+            vim.fn.chdir(vim.fn.stdpath("config"))
+            vim.fs.rm(pre_249_cwd, { recursive = true, force = true })
             ]])
         end,
     },


### PR DESCRIPTION
## Problem

On Git versions earlier than 2.49, parser installation initializes a
temporary repository and then runs `remote`, `fetch`, and `checkout`
without setting their working directory.

`--work-tree` does not select the repository, so Git attempts repository
discovery from Neovim's current working directory. This fails outside a
Git repository and may target an unrelated repository when Neovim is
started inside one.

## Fix

Run the three post-`git init` commands with `cwd = tmpdir`.

The explicit `--work-tree` argument is retained so that an inherited
`GIT_WORK_TREE` environment variable cannot override the temporary
working tree.

## Test

Run the simulated pre-2.49 tests from a non-repository directory.