### PR TITLE
fix(installer): fetch parser commit revisions directly

### DIFF
--- a/lua/tree-sitter-manager/installer.lua
+++ b/lua/tree-sitter-manager/installer.lua
@@ -64,19 +64,21 @@ local function install(lang, callback)
         callback({ ok = false, error = "Git not installed" })
         return
     end
-    version = { out.output:match("(%d+)%.(%d+)%.(%d+)") }
-    local major = tonumber(version[1])
-    local minor = tonumber(version[2])
-    local patch = tonumber(version[3])
-
     local info = util.get_repo_info(lang)
     local tmpdir = vim.fn.tempname()
     local build_path = vim.fs.joinpath(tmpdir, info.location)
-    local git_args = { "git", "--no-advice", "--work-tree=" .. tmpdir }
+    local git_args = {
+        "git",
+        "--no-advice",
+        "--git-dir=" .. vim.fs.joinpath(tmpdir, ".git"),
+        "--work-tree=" .. tmpdir,
+    }
 
-    if info.revision and (major < 2 or major == 2 and minor < 49) then
-        -- Git pre 2.49.0 doesn't have --revision flag
-        out = util.run({ "git", "init", tmpdir })
+    if info.revision then
+        -- `git clone --revision` only resolves advertised refs. Parser
+        -- revisions are commit IDs, so fetch the requested commit directly.
+        vim.fn.mkdir(tmpdir, "p")
+        out = util.run(util.concat(git_args, { "init" }))
         if out.ok then
             out = util.run(util.concat(git_args, { "remote", "add", "origin", info.url }))
         end
@@ -87,16 +89,10 @@ local function install(lang, callback)
             treesitter_build(lang, info.queries, build_path, info.generate, tmpdir, out, callback)
         end)
     else
-        local revision = info.revision and "--revision=" .. info.revision
         local branch = info.branch and "--branch=" .. info.branch
-        util.run_async(
-            util.concat(git_args, { "clone", "--depth=1", info.url, tmpdir, revision or branch }),
-            nil,
-            out,
-            function(out)
-                treesitter_build(lang, info.queries, build_path, info.generate, tmpdir, out, callback)
-            end
-        )
+        util.run_async({ "git", "--no-advice", "clone", "--depth=1", info.url, tmpdir, branch }, nil, out, function(out)
+            treesitter_build(lang, info.queries, build_path, info.generate, tmpdir, out, callback)
+        end)
     end
 end
 

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -7,6 +7,28 @@ T["revision"] = function()
     child.wait(languages)
 end
 
+T["raw commit revision"] = function()
+    if _G.languages then
+        MiniTest.skip()
+    end
+    -- `git clone --revision` cannot resolve this non-tip commit from GitHub.
+    local languages = { "markdown" }
+    child.setup({
+        ensure_installed = languages,
+        languages = {
+            markdown = {
+                install_info = {
+                    url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown",
+                    revision = "f969cd3ae3f9fbd4e43205431d0ae286014c05b5",
+                    location = "tree-sitter-markdown",
+                    generate = false,
+                },
+            },
+        },
+    })
+    child.wait(languages, 180000)
+end
+
 T["branch_revision"] = function()
     if _G.languages then
         MiniTest.skip()


### PR DESCRIPTION
## Summary

- fetch parser commit revisions directly with `git init` and `git fetch <sha>`
- reserve shallow `git clone` for branch/HEAD installs
- make the revision path independent of the caller's `GIT_WORK_TREE`
- cover a real non-tip markdown parser commit that `git clone --revision` cannot resolve

## Root cause

Git 2.49 introduced `git clone --revision`, but the option resolves advertised remote refs. The parser registry stores raw commit IDs; on Git 2.54 those installs fail with `Remote revision ... not found in upstream origin`, while `git fetch --depth=1 origin <sha>` succeeds.

## Validation

- `stylua --check lua tests`
- `make test_git` (8 cases, 0 failures)