### PR TITLE
Remove develop branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,6 +1,6 @@
 ---
 name: Issue Template
-about: Check develop before submitting
+about: ''
 title: ''
 labels: ''
 assignees: ''
@@ -8,4 +8,3 @@ assignees: ''
 ---
 
 - [ ] I have checked other open and closed issues and pull requests.
-- [ ] I have checked the `develop` branch the issue isn't fixed there.


### PR DESCRIPTION
I think we can go back to PR directly into main. As most features have been implemented. And it's going to be maintenance going forward after auto-update feature.

- [x] Issue template
- [ ] Rebase `fix-cpp20-incompatibility` #159 